### PR TITLE
fix bug on sanitizing params

### DIFF
--- a/postgrest_py/utils.py
+++ b/postgrest_py/utils.py
@@ -1,7 +1,7 @@
 def sanitize_param(param: str) -> str:
     reserved_chars = ",.:()"
     if any(char in param for char in reserved_chars):
-        return f'"{param}"'
+        return f'%22{param}%22'
     return param
 
 

--- a/tests/test_filter_request_builder.py
+++ b/tests/test_filter_request_builder.py
@@ -27,7 +27,7 @@ def test_not_(filter_request_builder):
 def test_filter(filter_request_builder):
     builder = filter_request_builder.filter(":col.name", "eq", "val")
 
-    assert builder.session.params['":col.name"'] == "eq.val"
+    assert builder.session.params['%22:col.name%22'] == "eq.val"
 
 
 def test_multivalued_param(filter_request_builder):


### PR DESCRIPTION
Signed-off-by: Bariq <bariqhibat@gmail.com>

This should fix https://github.com/supabase-community/supabase-py/issues/37

In this case, I don't think that http libraries that we use provide this URL encoding automatically, that's why the bug occured. Ultimately, it is also desired to assume that our http library does not though.

![image](https://user-images.githubusercontent.com/54849895/135866642-7468df4f-ad04-4704-892f-14cf7382bf72.png)
Ref: https://postgrest.org/en/v7.0.0/api.html
