### PR TITLE
feat: user models

### DIFF
--- a/postgrest_py/_async/request_builder.py
+++ b/postgrest_py/_async/request_builder.py
@@ -19,7 +19,6 @@ from ..exceptions import APIError
 from ..types import ReturnMethod
 from ..utils import AsyncClient
 
-
 ModelType = TypeVar("ModelType", bound=Union[BaseModel, Dict[str, Any]])
 
 
@@ -36,7 +35,9 @@ class AsyncQueryRequestBuilder:
         self.http_method = http_method
         self.json = json
 
-    async def execute(self, *, model: Type[ModelType] = Dict[str, Any]) -> APIResponse[ModelType]:
+    async def execute(
+        self, *, model: Type[ModelType] = Dict[str, Any]
+    ) -> APIResponse[ModelType]:
         r = await self.session.request(
             self.http_method,
             self.path,

--- a/postgrest_py/_async/request_builder.py
+++ b/postgrest_py/_async/request_builder.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Dict, Optional, Type, TypeVar, Union
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from ..base_request_builder import (
     APIResponse,
@@ -20,6 +20,9 @@ from ..types import ReturnMethod
 from ..utils import AsyncClient
 
 
+ModelType = TypeVar("ModelType", bound=Union[BaseModel, Dict[str, Any]])
+
+
 class AsyncQueryRequestBuilder:
     def __init__(
         self,
@@ -33,14 +36,14 @@ class AsyncQueryRequestBuilder:
         self.http_method = http_method
         self.json = json
 
-    async def execute(self) -> APIResponse:
+    async def execute(self, *, model: Type[ModelType] = Dict[str, Any]) -> APIResponse[ModelType]:
         r = await self.session.request(
             self.http_method,
             self.path,
             json=self.json,
         )
         try:
-            return APIResponse.from_http_request_response(r)
+            return APIResponse[model].from_http_request_response(r)
         except ValidationError as e:
             raise APIError(r.json()) from e
 

--- a/postgrest_py/_sync/request_builder.py
+++ b/postgrest_py/_sync/request_builder.py
@@ -19,7 +19,6 @@ from ..exceptions import APIError
 from ..types import ReturnMethod
 from ..utils import SyncClient
 
-
 ModelType = TypeVar("ModelType", bound=Union[BaseModel, Dict[str, Any]])
 
 
@@ -36,7 +35,9 @@ class SyncQueryRequestBuilder:
         self.http_method = http_method
         self.json = json
 
-    def execute(self, *, model: Type[ModelType] = Dict[str, Any]) -> APIResponse[ModelType]:
+    def execute(
+        self, *, model: Type[ModelType] = Dict[str, Any]
+    ) -> APIResponse[ModelType]:
         r = self.session.request(
             self.http_method,
             self.path,

--- a/postgrest_py/_sync/request_builder.py
+++ b/postgrest_py/_sync/request_builder.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Dict, Optional, Type, TypeVar, Union
+
+from pydantic import BaseModel
 
 from ..base_request_builder import (
     APIResponse,
@@ -18,6 +20,9 @@ from ..types import ReturnMethod
 from ..utils import SyncClient
 
 
+ModelType = TypeVar("ModelType", bound=Union[BaseModel, Dict[str, Any]])
+
+
 class SyncQueryRequestBuilder:
     def __init__(
         self,
@@ -31,14 +36,14 @@ class SyncQueryRequestBuilder:
         self.http_method = http_method
         self.json = json
 
-    def execute(self) -> APIResponse:
+    def execute(self, *, model: Type[ModelType] = Dict[str, Any]) -> APIResponse[ModelType]:
         r = self.session.request(
             self.http_method,
             self.path,
             json=self.json,
         )
         try:
-            return APIResponse.from_http_request_response(r)
+            return APIResponse[model].from_http_request_response(r)
         except ValueError as e:
             raise APIError(r.json()) from e
 

--- a/postgrest_py/base_request_builder.py
+++ b/postgrest_py/base_request_builder.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 from re import search
-from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from httpx import Response as RequestResponse
-from pydantic import BaseModel, validator
+from pydantic import validator
 from pydantic.generics import GenericModel
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
@@ -88,6 +99,7 @@ def pre_delete(
 
 
 _ModelOrJSON = TypeVar("_ModelOrJSON")  # a pydantic BaseModel, or Dict[str, Any]
+
 
 class APIResponse(GenericModel, Generic[_ModelOrJSON]):
     data: List[_ModelOrJSON]

--- a/postgrest_py/base_request_builder.py
+++ b/postgrest_py/base_request_builder.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from re import search
-from typing import Any, Dict, Iterable, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, Type, TypeVar, Union
 
 from httpx import Response as RequestResponse
 from pydantic import BaseModel, validator
+from pydantic.generics import GenericModel
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
 from .utils import AsyncClient, SyncClient, sanitize_param, sanitize_pattern_param
@@ -86,8 +87,10 @@ def pre_delete(
     return RequestMethod.DELETE, {}
 
 
-class APIResponse(BaseModel):
-    data: Any
+_ModelOrJSON = TypeVar("_ModelOrJSON")  # a pydantic BaseModel, or Dict[str, Any]
+
+class APIResponse(GenericModel, Generic[_ModelOrJSON]):
+    data: List[_ModelOrJSON]
     count: Optional[int] = None
 
     @validator("data")


### PR DESCRIPTION
This pull request makes `APIResponse`, and the request builders' `.execute` methods generic, to allow users to pass their own pydantic BaseModels to use as response models.
Example:
```py
from datetime import datetime
from typing import Optional, List

from postgrest_py import SyncPostgrestClient as Client
from pydantic import BaseModel

client = SyncPostgrestClient(...)

class City(BaseModel):
    id: Optional[int]
    created_at: Optional[datetime]
    country_id: Optional[int]
    city_name: Optional[str]


class Country(BaseModel):
    id: Optional[int]
    created_at: Optional[datetime]
    country_name: Optional[str]
    capital: Optional[str]
    cities: Optional[List[City]]

r = client.from_("countries").select("*,cities(*)").execute()
reveal_type(r.data)  # Type is List[Dict[str, Any]]

r = client.from_("countries").select("*,cities(*)").execute(model=Country)
reveal_type(r.data)  # Type is List[Country]
```