### PR TITLE
feat: add .contains and .contained_by operators to match JS client

### DIFF
--- a/postgrest_py/base_request_builder.py
+++ b/postgrest_py/base_request_builder.py
@@ -219,9 +219,9 @@ class BaseFilterRequestBuilder:
             # Expected to be some type of iterable
             stringified_values = ",".join(value)
             return self.filter(column, Filters.CS, f"{{{stringified_values}}}")
-        
+
         return self.filter(column, Filters.CS, json.dumps(value))
-    
+
     def contained_by(self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]):
         if isinstance(value, str):
             # range

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -51,22 +51,26 @@ def test_contains(filter_request_builder):
 def test_contains_dictionary(filter_request_builder):
     builder = filter_request_builder.contains("x", {"a": "b"})
 
+    # {"a":"b"}
     assert str(builder.session.params) == "x=cs.%7B%22a%22%3A+%22b%22%7D"
 
 
 def test_contains_any_item(filter_request_builder):
     builder = filter_request_builder.contains("x", ["a", "b"])
 
+    # {a,b}
     assert str(builder.session.params) == "x=cs.%7Ba%2Cb%7D"
 
 
 def test_contains_in_list(filter_request_builder):
     builder = filter_request_builder.contains("x", '[{"a": "b"}]')
 
+    # [{"a":+"b"}] (the + represents the space)
     assert str(builder.session.params) == "x=cs.%5B%7B%22a%22%3A+%22b%22%7D%5D"
 
 
 def test_contained_by_mixed_items(filter_request_builder):
     builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
 
+    # {a,["b",+"c"]}
     assert str(builder.session.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -40,3 +40,33 @@ def test_multivalued_param(filter_request_builder):
 def test_match(filter_request_builder):
     builder = filter_request_builder.match({"id": "1", "done": "false"})
     assert str(builder.session.params) == "id=eq.1&done=eq.false"
+
+
+def test_contains(filter_request_builder):
+    builder = filter_request_builder.contains("x", "a")
+
+    assert str(builder.session.params) == "x=cs.a"
+
+
+def test_contains_dictionary(filter_request_builder):
+    builder = filter_request_builder.contains("x", {"a": "b"})
+
+    assert str(builder.session.params) == "x=cs.%7B%22a%22%3A+%22b%22%7D"
+
+
+def test_contains_any_item(filter_request_builder):
+    builder = filter_request_builder.contains("x", ["a", "b"])
+
+    assert str(builder.session.params) == "x=cs.%7Ba%2Cb%7D"
+
+
+def test_contains_in_list(filter_request_builder):
+    builder = filter_request_builder.contains("x", '[{"a": "b"}]')
+
+    assert str(builder.session.params) == "x=cs.%5B%7B%22a%22%3A+%22b%22%7D%5D"
+
+
+def test_contained_by_mixed_items(filter_request_builder):
+    builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
+
+    assert str(builder.session.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -51,22 +51,26 @@ def test_contains(filter_request_builder):
 def test_contains_dictionary(filter_request_builder):
     builder = filter_request_builder.contains("x", {"a": "b"})
 
+    # {"a":"b"}
     assert str(builder.session.params) == "x=cs.%7B%22a%22%3A+%22b%22%7D"
 
 
 def test_contains_any_item(filter_request_builder):
     builder = filter_request_builder.contains("x", ["a", "b"])
 
+    # {a,b}
     assert str(builder.session.params) == "x=cs.%7Ba%2Cb%7D"
 
 
 def test_contains_in_list(filter_request_builder):
     builder = filter_request_builder.contains("x", '[{"a": "b"}]')
 
+    # [{"a":+"b"}] (the + represents the space)
     assert str(builder.session.params) == "x=cs.%5B%7B%22a%22%3A+%22b%22%7D%5D"
 
 
 def test_contained_by_mixed_items(filter_request_builder):
     builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
 
+    # {a,["b",+"c"]}
     assert str(builder.session.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -40,3 +40,33 @@ def test_multivalued_param(filter_request_builder):
 def test_match(filter_request_builder):
     builder = filter_request_builder.match({"id": "1", "done": "false"})
     assert str(builder.session.params) == "id=eq.1&done=eq.false"
+
+
+def test_contains(filter_request_builder):
+    builder = filter_request_builder.contains("x", "a")
+
+    assert str(builder.session.params) == "x=cs.a"
+
+
+def test_contains_dictionary(filter_request_builder):
+    builder = filter_request_builder.contains("x", {"a": "b"})
+
+    assert str(builder.session.params) == "x=cs.%7B%22a%22%3A+%22b%22%7D"
+
+
+def test_contains_any_item(filter_request_builder):
+    builder = filter_request_builder.contains("x", ["a", "b"])
+
+    assert str(builder.session.params) == "x=cs.%7Ba%2Cb%7D"
+
+
+def test_contains_in_list(filter_request_builder):
+    builder = filter_request_builder.contains("x", '[{"a": "b"}]')
+
+    assert str(builder.session.params) == "x=cs.%5B%7B%22a%22%3A+%22b%22%7D%5D"
+
+
+def test_contained_by_mixed_items(filter_request_builder):
+    builder = filter_request_builder.contained_by("x", ["a", '["b", "c"]'])
+
+    assert str(builder.session.params) == "x=cd.%7Ba%2C%5B%22b%22%2C+%22c%22%5D%7D"


### PR DESCRIPTION
This change fixes https://github.com/supabase-community/postgrest-py/issues/99.

Specifically, this change enables a PostgREST `cs.***` query that searches an Array, such as `[{"foo": "bar"}]`. This aim to to keep the same API as `.cs`/`.cd`, modeled after the [JS library's implementations](https://github.com/supabase/postgrest-js/blob/f6683f1babd471527c87b7b70212a9d1091b6e0e/src/lib/PostgrestFilterBuilder.ts#L206-L250).