### PR TITLE
fix: escape chars only when necessary

### DIFF
--- a/postgrest_py/base_request_builder.py
+++ b/postgrest_py/base_request_builder.py
@@ -8,7 +8,7 @@ from httpx import Response as RequestResponse
 from pydantic import BaseModel, validator
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
-from .utils import AsyncClient, SyncClient, sanitize_param, sanitize_pattern_param
+from .utils import AsyncClient, SyncClient, sanitize_param
 
 
 def pre_select(
@@ -152,48 +152,48 @@ class BaseFilterRequestBuilder:
         if self.negate_next is True:
             self.negate_next = False
             operator = f"{Filters.NOT}.{operator}"
-        key, val = sanitize_param(column), f"{operator}.{criteria}"
+        key, val = column, f"{operator}.{criteria}"
         self.session.params = self.session.params.add(key, val)
         return self
 
     def eq(self, column: str, value: Any):
-        return self.filter(column, Filters.EQ, sanitize_param(value))
+        return self.filter(column, Filters.EQ, value)
 
     def neq(self, column: str, value: Any):
-        return self.filter(column, Filters.NEQ, sanitize_param(value))
+        return self.filter(column, Filters.NEQ, value)
 
     def gt(self, column: str, value: Any):
-        return self.filter(column, Filters.GT, sanitize_param(value))
+        return self.filter(column, Filters.GT, value)
 
     def gte(self, column: str, value: Any):
-        return self.filter(column, Filters.GTE, sanitize_param(value))
+        return self.filter(column, Filters.GTE, value)
 
     def lt(self, column: str, value: Any):
-        return self.filter(column, Filters.LT, sanitize_param(value))
+        return self.filter(column, Filters.LT, value)
 
     def lte(self, column: str, value: Any):
-        return self.filter(column, Filters.LTE, sanitize_param(value))
+        return self.filter(column, Filters.LTE, value)
 
     def is_(self, column: str, value: Any):
-        return self.filter(column, Filters.IS, sanitize_param(value))
+        return self.filter(column, Filters.IS, value)
 
     def like(self, column: str, pattern: Any):
-        return self.filter(column, Filters.LIKE, sanitize_pattern_param(pattern))
+        return self.filter(column, Filters.LIKE, pattern)
 
     def ilike(self, column: str, pattern: Any):
-        return self.filter(column, Filters.ILIKE, sanitize_pattern_param(pattern))
+        return self.filter(column, Filters.ILIKE, pattern)
 
     def fts(self, column: str, query: Any):
-        return self.filter(column, Filters.FTS, sanitize_param(query))
+        return self.filter(column, Filters.FTS, query)
 
     def plfts(self, column: str, query: Any):
-        return self.filter(column, Filters.PLFTS, sanitize_param(query))
+        return self.filter(column, Filters.PLFTS, query)
 
     def phfts(self, column: str, query: Any):
-        return self.filter(column, Filters.PHFTS, sanitize_param(query))
+        return self.filter(column, Filters.PHFTS, query)
 
     def wfts(self, column: str, query: Any):
-        return self.filter(column, Filters.WFTS, sanitize_param(query))
+        return self.filter(column, Filters.WFTS, query)
 
     def in_(self, column: str, values: Iterable[Any]):
         values = map(sanitize_param, values)
@@ -201,12 +201,10 @@ class BaseFilterRequestBuilder:
         return self.filter(column, Filters.IN, f"({values})")
 
     def cs(self, column: str, values: Iterable[Any]):
-        values = map(sanitize_param, values)
         values = ",".join(values)
         return self.filter(column, Filters.CS, f"{{{values}}}")
 
     def cd(self, column: str, values: Iterable[Any]):
-        values = map(sanitize_param, values)
         values = ",".join(values)
         return self.filter(column, Filters.CD, f"{{{values}}}")
 
@@ -232,7 +230,6 @@ class BaseFilterRequestBuilder:
         return self.filter(column, Filters.CD, json.dumps(value))
 
     def ov(self, column: str, values: Iterable[Any]):
-        values = map(sanitize_param, values)
         values = ",".join(values)
         return self.filter(column, Filters.OV, f"{{{values}}}")
 

--- a/postgrest_py/utils.py
+++ b/postgrest_py/utils.py
@@ -13,7 +13,7 @@ class SyncClient(BaseClient):
 
 def sanitize_param(param: Any) -> str:
     param_str = str(param)
-    reserved_chars = ",.:()"
+    reserved_chars = ",()"
     if any(char in param_str for char in reserved_chars):
         return f'"{param_str}"'
     return param_str


### PR DESCRIPTION
Closes supabase-community/supabase-py#181 and supabase-community/supabase-py#161

Previously, `utils.sanitize_param` was used in every filter method.
It also escaped any value that contained the PostgREST special chars i.e
`.,:()`
For whatever reason, PostgREST seems to have changed the behaviour of
this escaping. The value needs to be escaped only if it contains any of
,() and it is only needed to be escaped in the `in` filter.

Corresponding postgrest-js commit: [5c36f1d8f2fbf0d349bed970497f1980a1fa1f6b](https://github.com/supabase/postgrest-js/commit/5c36f1d8f2fbf0d349bed970497f1980a1fa1f6b)