### PR TITLE
fix: include source directory name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,18 @@ name = "postgrest-py"
 version = "0.10.1"
 description = "PostgREST client for Python. This library provides an ORM interface to PostgREST."
 authors = ["Lương Quang Mạnh <luongquangmanh85@gmail.com>"]
-homepage = "https://github.com/supabase/postgrest-py"
-repository = "https://github.com/supabase/postgrest-py"
-documentation = "https://github.com/supabase/postgrest-py"
+homepage = "https://github.com/supabase-community/postgrest-py"
+repository = "https://github.com/supabase-community/postgrest-py"
+documentation = "https://postgrest-py.rtfd.io"
 readme = "README.md"
 license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
+]
+packages = [
+    { include = "postgrest" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Poetry by default looks for a directory with the same name as the
project as the source directory. However as our project is named
postgrest-py, but we migrated to the postgrest namespace, we need to
explicitly tell poetry where to look for the source code.