### PR TITLE
Add Python 3.11 to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Clone Repository


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add Python 3.11 to the build matrix.

## What is the current behavior?

CI python versions stop at 3.10.

## What is the new behavior?

Introduces python version 3.11.

## Additional context

This PR is being introduced as pre-requisite to addressing https://github.com/supabase-community/postgrest-py/issues/169.