### PR TITLE
feat: add support for 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Clone Repository

--- a/poetry.lock
+++ b/poetry.lock
@@ -1767,6 +1767,23 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "strenum"
+version = "0.4.9"
+description = "An Enum that inherits from str."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "StrEnum-0.4.9-py3-none-any.whl", hash = "sha256:c3df653030837b8077b2eb929738283481f01b07c7ef73ab4db368449830cc46"},
+    {file = "StrEnum-0.4.9.tar.gz", hash = "sha256:1b15ccff9eb0e22e77b8f874366ea752754280adc9144e6e388705d14cc350e7"},
+]
+
+[package.extras]
+docs = ["myst-parser[linkify]", "sphinx", "sphinx-rtd-theme"]
+release = ["twine"]
+test = ["pylint", "pytest", "pytest-black", "pytest-cov", "pytest-pylint"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -2016,4 +2033,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "6fcc218c197f6b2fb4f52131919c658dc889bd15e3cd7168651391d3a8867777"
+content-hash = "c79f81b084c8259a2b7f9cf135788418ec6766501e6def11de58a7e4be25c2b1"

--- a/postgrest/types.py
+++ b/postgrest/types.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 from enum import Enum
 
+import sys
 
-class CountMethod(str, Enum):
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from strenum import StrEnum
+
+class CountMethod(StrEnum):
     exact = "exact"
     planned = "planned"
     estimated = "estimated"
 
 
-class Filters(str, Enum):
+class Filters(StrEnum):
     NOT = "not"
     EQ = "eq"
     NEQ = "neq"
@@ -35,7 +41,7 @@ class Filters(str, Enum):
     ADJ = "adj"
 
 
-class RequestMethod(str, Enum):
+class RequestMethod(StrEnum):
     GET = "GET"
     POST = "POST"
     PATCH = "PATCH"
@@ -44,6 +50,6 @@ class RequestMethod(str, Enum):
     HEAD = "HEAD"
 
 
-class ReturnMethod(str, Enum):
+class ReturnMethod(StrEnum):
     minimal = "minimal"
     representation = "representation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ python = "^3.7"
 httpx = "^0.23.0"
 deprecation = "^2.1.0"
 pydantic = "^1.9.0"
+strenum = "^0.4.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"


### PR DESCRIPTION
see title- makes use of first solution in #169 - we add `StrEnum` and import [StrEnum](https://github.com/supabase-community/postgrest-py/issues/169) for older versions
