### PR TITLE
Fix sanitize_params to correctly resolve nested columns

### DIFF
--- a/postgrest/utils.py
+++ b/postgrest/utils.py
@@ -13,7 +13,7 @@ class SyncClient(BaseClient):
 
 def sanitize_param(param: Any) -> str:
     param_str = str(param)
-    reserved_chars = ".,:()"
+    reserved_chars = ",:()"
     if any(char in param_str for char in reserved_chars):
         return f'"{param_str}"'
     return param_str

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -36,6 +36,21 @@ def test_filter(filter_request_builder):
     assert builder.params['":col.name"'] == "eq.val"
 
 
+@pytest.mark.parametrize(
+    "col_name, expected_query_prefix",
+    [
+        ("col:name", "%22col%3Aname%22"),
+        ("col.name", "col.name"),
+    ],
+)
+def test_filter_special_characters(
+    filter_request_builder, col_name, expected_query_prefix
+):
+    builder = filter_request_builder.filter(col_name, "eq", "val")
+
+    assert str(builder.params) == expected_query_prefix + "=eq.val"
+
+
 def test_multivalued_param(filter_request_builder):
     builder = filter_request_builder.lte("x", "a").gte("x", "b")
 

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -62,6 +62,12 @@ def test_match(filter_request_builder):
     assert str(builder.params) == "id=eq.1&done=eq.false"
 
 
+def test_equals(filter_request_builder):
+    builder = filter_request_builder.eq("x", "a")
+
+    assert str(builder.params) == "x=eq.a"
+
+
 def test_contains(filter_request_builder):
     builder = filter_request_builder.contains("x", "a")
 

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -36,6 +36,21 @@ def test_filter(filter_request_builder):
     assert builder.params['":col.name"'] == "eq.val"
 
 
+@pytest.mark.parametrize(
+    "col_name, expected_query_prefix",
+    [
+        ("col:name", "%22col%3Aname%22"),
+        ("col.name", "col.name"),
+    ],
+)
+def test_filter_special_characters(
+    filter_request_builder, col_name, expected_query_prefix
+):
+    builder = filter_request_builder.filter(col_name, "eq", "val")
+
+    assert str(builder.params) == expected_query_prefix + "=eq.val"
+
+
 def test_multivalued_param(filter_request_builder):
     builder = filter_request_builder.lte("x", "a").gte("x", "b")
 

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -62,6 +62,12 @@ def test_match(filter_request_builder):
     assert str(builder.params) == "id=eq.1&done=eq.false"
 
 
+def test_equals(filter_request_builder):
+    builder = filter_request_builder.eq("x", "a")
+
+    assert str(builder.params) == "x=eq.a"
+
+
 def test_contains(filter_request_builder):
     builder = filter_request_builder.contains("x", "a")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+
+from postgrest.utils import sanitize_param
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("param,name", '"param,name"'),
+        ("param:name", '"param:name"'),
+        ("param(name", '"param(name"'),
+        ("param)name", '"param)name"'),
+        ("param,name", '"param,name"'),
+        ("table.column", "table.column"),
+        ("table_column", "table_column"),
+    ],
+)
+def test_sanitize_params(value, expected):
+    assert sanitize_param(value) == expected


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Nested columns (of the form `foreign_table.column`) are currently escaped which breaks the API exposed by postgrest.

https://github.com/supabase-community/postgrest-py/issues/189
https://github.com/supabase-community/postgrest-py/issues/202

## What is the new behavior?
This PR modifies the sanitize_parameters() function so that the `.` character is not escaped anymore.
It also adds some test to verify this behavior.