### PR TITLE
`maybe_single` with no matching rows returns None

### DIFF
--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -122,19 +122,13 @@ class AsyncSingleRequestBuilder:
 
 
 class AsyncMaybeSingleRequestBuilder(AsyncSingleRequestBuilder):
-    async def execute(self) -> SingleAPIResponse:
+    async def execute(self) -> Optional[SingleAPIResponse]:
         r = None
         try:
             r = await super().execute()
         except APIError as e:
             if e.details and "Results contain 0 rows" in e.details:
-                return SingleAPIResponse.from_dict(
-                    {
-                        "data": None,
-                        "error": None,
-                        "count": 0,  # NOTE: needs to take value from res.count
-                    }
-                )
+                return None
         if not r:
             raise APIError(
                 {

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -122,19 +122,13 @@ class SyncSingleRequestBuilder:
 
 
 class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder):
-    def execute(self) -> SingleAPIResponse:
+    def execute(self) -> Optional[SingleAPIResponse]:
         r = None
         try:
             r = super().execute()
         except APIError as e:
             if e.details and "Results contain 0 rows" in e.details:
-                return SingleAPIResponse.from_dict(
-                    {
-                        "data": None,
-                        "error": None,
-                        "count": 0,  # NOTE: needs to take value from res.count
-                    }
-                )
+                return None
         if not r:
             raise APIError(
                 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - closes #230 . The maybe_single method now returns None when the query returns 0 rows.

## What is the current behavior?
maybe_single errors out on responses with 0 rows, while trying to create a `SingleAPIResponse` with it's `data` field set to None, which pydantic rejects.
