### PR TITLE
Re-enable pydantic 1.9

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -18,7 +18,14 @@ from typing import (
 
 from httpx import Headers, QueryParams
 from httpx import Response as RequestResponse
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
+
+try:
+    # >= 2.0.0
+    from pydantic import field_validator
+except ImportError:
+    # < 2.0.0
+    from pydantic import validator as field_validator
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
 from .utils import AsyncClient, SyncClient, sanitize_param

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 python = "^3.8"
 httpx = "^0.24.0"
 deprecation = "^2.1.0"
-pydantic = ">=2.1.0,<3.0"
+pydantic = ">=1.9,<3.0"
 strenum = "^0.4.9"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## What kind of change does this PR introduce?
As a library we need to be maximally compatible with downstream applications

- pydantic is common dependency
- pydantic 2.1 only a few weeks old
- many users of pydantic and postgrest-py (direct and indirect through supabase-py) have not upgraded to pydantic 2 yet

This PR re-enables pydantic 1.9 for those who have not upgraded yet (for example, Langchain)

resolves #282