### PR TITLE
fix: maybe_single return None when no matching result found in database.

### DIFF
--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -127,7 +127,7 @@ class AsyncMaybeSingleRequestBuilder(AsyncSingleRequestBuilder):
         try:
             r = await super().execute()
         except APIError as e:
-            if e.details and "Results contain 0 rows" in e.details:
+            if e.details and "The result contains 0 rows" in e.details:
                 return None
         if not r:
             raise APIError(

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -127,7 +127,7 @@ class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder):
         try:
             r = super().execute()
         except APIError as e:
-            if e.details and "Results contain 0 rows" in e.details:
+            if e.details and "The result contains 0 rows" in e.details:
                 return None
         if not r:
             raise APIError(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

**Issue** - The `maybe_single` method seems to work when there is a single record in the database matching the query, but if there are no matching results in the database, an error is raised.
https://github.com/supabase-community/supabase-py/issues/511

**Reason** - Error message is been updated in postgREST https://github.com/PostgREST/postgrest/pull/2876

## What is the new behavior?

New changes return None when no matching result found in database.

