### PR TITLE
fix: remove pydantic validation for rpc calls

### DIFF
--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -60,10 +60,12 @@ class AsyncQueryRequestBuilder:
             headers=self.headers,
         )
         try:
-            if (
-                200 <= r.status_code <= 299
+            if (200 <= r.status_code <= 299) and "/rpc" in str(
+                r.request.url
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return APIResponse.from_http_request_response(r)
+            elif 200 <= r.status_code <= 299:
+                return r.json()
             else:
                 raise APIError(r.json())
         except ValidationError as e:

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -60,12 +60,12 @@ class AsyncQueryRequestBuilder:
             headers=self.headers,
         )
         try:
-            if (200 <= r.status_code <= 299) and "/rpc" in str(
-                r.request.url
-            ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
-                return APIResponse.from_http_request_response(r)
-            elif 200 <= r.status_code <= 299:
+            # RPC calls should be excluded from validation
+            if (200 <= r.status_code <= 299) and "/rpc" in str(r.request.url):
                 return r.json()
+            elif 200 <= r.status_code <= 299:
+                # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
+                return APIResponse.from_http_request_response(r)
             else:
                 raise APIError(r.json())
         except ValidationError as e:

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -62,7 +62,13 @@ class AsyncQueryRequestBuilder:
         try:
             # RPC calls should be excluded from validation
             if (200 <= r.status_code <= 299) and "/rpc" in str(r.request.url):
-                return r.json()
+                # No content, indicative of null rpc response
+                if r.status_code == 204:
+                    return None
+                try:
+                    return r.json()
+                except JSONDecodeError as e:
+                    return e
             elif 200 <= r.status_code <= 299:
                 # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return APIResponse.from_http_request_response(r)

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -60,10 +60,12 @@ class SyncQueryRequestBuilder:
             headers=self.headers,
         )
         try:
-            if (
-                200 <= r.status_code <= 299
+            if (200 <= r.status_code <= 299) and "/rpc" in str(
+                r.request.url
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return APIResponse.from_http_request_response(r)
+            elif 200 <= r.status_code <= 299:
+                return r.json()
             else:
                 raise APIError(r.json())
         except ValidationError as e:

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -60,12 +60,12 @@ class SyncQueryRequestBuilder:
             headers=self.headers,
         )
         try:
-            if (200 <= r.status_code <= 299) and "/rpc" in str(
-                r.request.url
-            ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
-                return APIResponse.from_http_request_response(r)
-            elif 200 <= r.status_code <= 299:
+            # RPC calls should be excluded from validation
+            if (200 <= r.status_code <= 299) and "/rpc" in str(r.request.url):
                 return r.json()
+            elif 200 <= r.status_code <= 299:
+                # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
+                return APIResponse.from_http_request_response(r)
             else:
                 raise APIError(r.json())
         except ValidationError as e:

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -62,7 +62,13 @@ class SyncQueryRequestBuilder:
         try:
             # RPC calls should be excluded from validation
             if (200 <= r.status_code <= 299) and "/rpc" in str(r.request.url):
-                return r.json()
+                # No content, indicative of null rpc response
+                if r.status_code == 204:
+                    return None
+                try:
+                    return r.json()
+                except JSONDecodeError as e:
+                    return e
             elif 200 <= r.status_code <= 299:
                 # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return APIResponse.from_http_request_response(r)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, there is validation on `/rpc` calls which don't return responses in the conventional


```
{
  data: ...
}
```
 format. This causes validation to fail and an error to be throw.

Current fix is hacky - open to suggestions on cleaner ways to fix this

Aims to fix: https://github.com/supabase-community/supabase-py/issues/405 and #200 


Manually tested - briefly converting to draft so I can write a test