### PR TITLE
feat: generic query builders

### DIFF
--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -12,9 +12,9 @@ from ..constants import (
     DEFAULT_POSTGREST_CLIENT_TIMEOUT,
 )
 from ..utils import AsyncClient
-from .request_builder import AsyncFilterRequestBuilder, AsyncRequestBuilder
+from .request_builder import AsyncRequestBuilder, AsyncRPCFilterRequestBuilder
 
-_TableT = List[Dict[str, Any]]
+_TableT = Dict[str, Any]
 
 
 class AsyncPostgrestClient(BasePostgrestClient):
@@ -78,24 +78,26 @@ class AsyncPostgrestClient(BasePostgrestClient):
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
-    async def rpc(self, func: str, params: dict) -> AsyncFilterRequestBuilder[Any]:
+    async def rpc(self, func: str, params: dict) -> AsyncRPCFilterRequestBuilder[Any]:
         """Perform a stored procedure call.
 
         Args:
             func: The name of the remote procedure to run.
             params: The parameters to be passed to the remote procedure.
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`AsyncRPCFilterRequestBuilder`
         Example:
             .. code-block:: python
 
                 await client.rpc("foobar", {"arg": "value"}).execute()
 
-        .. versionchanged:: 0.11.0
+        .. versionchanged:: 0.10.9
+            This method now returns a :class:`AsyncRPCFilterRequestBuilder`.
+        .. versionchanged:: 0.10.2
             This method now returns a :class:`AsyncFilterRequestBuilder` which allows you to
             filter on the RPC's resultset.
         """
         # the params here are params to be sent to the RPC and not the queryparams!
-        return AsyncFilterRequestBuilder[Any](
+        return AsyncRPCFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", "POST", Headers(), QueryParams(), json=params
         )

--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, List, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -14,7 +14,7 @@ from ..constants import (
 from ..utils import AsyncClient
 from .request_builder import AsyncFilterRequestBuilder, AsyncRequestBuilder
 
-_TableT = list[dict[str, Any]]
+_TableT = List[Dict[str, Any]]
 
 
 class AsyncPostgrestClient(BasePostgrestClient):

--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Union, cast
+from typing import Any, Dict, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -13,6 +13,8 @@ from ..constants import (
 )
 from ..utils import AsyncClient
 from .request_builder import AsyncFilterRequestBuilder, AsyncRequestBuilder
+
+_TableT = list[dict[str, Any]]
 
 
 class AsyncPostgrestClient(BasePostgrestClient):
@@ -57,7 +59,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
         """Close the underlying HTTP connections."""
         await self.session.aclose()
 
-    def from_(self, table: str) -> AsyncRequestBuilder:
+    def from_(self, table: str) -> AsyncRequestBuilder[_TableT]:
         """Perform a table operation.
 
         Args:
@@ -65,9 +67,9 @@ class AsyncPostgrestClient(BasePostgrestClient):
         Returns:
             :class:`AsyncRequestBuilder`
         """
-        return AsyncRequestBuilder(self.session, f"/{table}")
+        return AsyncRequestBuilder[_TableT](self.session, f"/{table}")
 
-    def table(self, table: str) -> AsyncRequestBuilder:
+    def table(self, table: str) -> AsyncRequestBuilder[_TableT]:
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
@@ -76,7 +78,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
-    async def rpc(self, func: str, params: dict) -> AsyncFilterRequestBuilder:
+    async def rpc(self, func: str, params: dict) -> AsyncFilterRequestBuilder[Any]:
         """Perform a stored procedure call.
 
         Args:
@@ -94,6 +96,6 @@ class AsyncPostgrestClient(BasePostgrestClient):
             filter on the RPC's resultset.
         """
         # the params here are params to be sent to the RPC and not the queryparams!
-        return AsyncFilterRequestBuilder(
+        return AsyncFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", "POST", Headers(), QueryParams(), json=params
         )

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -165,6 +165,27 @@ class AsyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], AsyncQueryRe
         )
 
 
+# this exists for type-safety. see https://gist.github.com/anand2312/93d3abf401335fd3310d9e30112303bf
+class AsyncRPCFilterRequestBuilder(
+    BaseFilterRequestBuilder[_ReturnT], AsyncSingleRequestBuilder[_ReturnT]
+):
+    def __init__(
+        self,
+        session: AsyncClient,
+        path: str,
+        http_method: str,
+        headers: Headers,
+        params: QueryParams,
+        json: dict,
+    ) -> None:
+        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, headers, params
+        )
+        AsyncSingleRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, path, http_method, headers, params, json
+        )
+
+
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
 class AsyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], AsyncQueryRequestBuilder[_ReturnT]):  # type: ignore
     def __init__(

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -20,7 +20,7 @@ from ..base_request_builder import (
 )
 from ..exceptions import APIError, generate_default_error_message
 from ..types import ReturnMethod
-from ..utils import AsyncClient
+from ..utils import AsyncClient, get_origin_and_cast
 
 _ReturnT = TypeVar("_ReturnT")
 
@@ -154,13 +154,10 @@ class AsyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], AsyncQueryRe
         params: QueryParams,
         json: dict,
     ) -> None:
-        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
-        # tries to call _GenericAlias.__init__ - which is the wrong method
-        # The __origin__ attribute of the _GenericAlias is the actual class
-        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseFilterRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        AsyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(AsyncQueryRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 
@@ -178,10 +175,10 @@ class AsyncRPCFilterRequestBuilder(
         params: QueryParams,
         json: dict,
     ) -> None:
-        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseFilterRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        AsyncSingleRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(AsyncSingleRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 
@@ -197,13 +194,10 @@ class AsyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], AsyncQueryRe
         params: QueryParams,
         json: dict,
     ) -> None:
-        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
-        # tries to call _GenericAlias.__init__ - which is the wrong method
-        # The __origin__ attribute of the _GenericAlias is the actual class
-        BaseSelectRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseSelectRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        AsyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(AsyncQueryRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -12,9 +12,9 @@ from ..constants import (
     DEFAULT_POSTGREST_CLIENT_TIMEOUT,
 )
 from ..utils import SyncClient
-from .request_builder import SyncFilterRequestBuilder, SyncRequestBuilder
+from .request_builder import SyncRequestBuilder, SyncRPCFilterRequestBuilder
 
-_TableT = List[Dict[str, Any]]
+_TableT = Dict[str, Any]
 
 
 class SyncPostgrestClient(BasePostgrestClient):
@@ -78,24 +78,26 @@ class SyncPostgrestClient(BasePostgrestClient):
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
-    def rpc(self, func: str, params: dict) -> SyncFilterRequestBuilder[Any]:
+    def rpc(self, func: str, params: dict) -> SyncRPCFilterRequestBuilder[Any]:
         """Perform a stored procedure call.
 
         Args:
             func: The name of the remote procedure to run.
             params: The parameters to be passed to the remote procedure.
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`AsyncRPCFilterRequestBuilder`
         Example:
             .. code-block:: python
 
                 await client.rpc("foobar", {"arg": "value"}).execute()
 
-        .. versionchanged:: 0.11.0
+        .. versionchanged:: 0.10.9
+            This method now returns a :class:`AsyncRPCFilterRequestBuilder`.
+        .. versionchanged:: 0.10.2
             This method now returns a :class:`AsyncFilterRequestBuilder` which allows you to
             filter on the RPC's resultset.
         """
         # the params here are params to be sent to the RPC and not the queryparams!
-        return SyncFilterRequestBuilder[Any](
+        return SyncRPCFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", "POST", Headers(), QueryParams(), json=params
         )

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, List, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -14,7 +14,7 @@ from ..constants import (
 from ..utils import SyncClient
 from .request_builder import SyncFilterRequestBuilder, SyncRequestBuilder
 
-_TableT = list[dict[str, Any]]
+_TableT = List[Dict[str, Any]]
 
 
 class SyncPostgrestClient(BasePostgrestClient):

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Union, cast
+from typing import Any, Dict, Union, cast
 
 from deprecation import deprecated
 from httpx import Headers, QueryParams, Timeout
@@ -13,6 +13,8 @@ from ..constants import (
 )
 from ..utils import SyncClient
 from .request_builder import SyncFilterRequestBuilder, SyncRequestBuilder
+
+_TableT = list[dict[str, Any]]
 
 
 class SyncPostgrestClient(BasePostgrestClient):
@@ -57,7 +59,7 @@ class SyncPostgrestClient(BasePostgrestClient):
         """Close the underlying HTTP connections."""
         self.session.aclose()
 
-    def from_(self, table: str) -> SyncRequestBuilder:
+    def from_(self, table: str) -> SyncRequestBuilder[_TableT]:
         """Perform a table operation.
 
         Args:
@@ -65,9 +67,9 @@ class SyncPostgrestClient(BasePostgrestClient):
         Returns:
             :class:`AsyncRequestBuilder`
         """
-        return SyncRequestBuilder(self.session, f"/{table}")
+        return SyncRequestBuilder[_TableT](self.session, f"/{table}")
 
-    def table(self, table: str) -> SyncRequestBuilder:
+    def table(self, table: str) -> SyncRequestBuilder[_TableT]:
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
@@ -76,7 +78,7 @@ class SyncPostgrestClient(BasePostgrestClient):
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
-    def rpc(self, func: str, params: dict) -> SyncFilterRequestBuilder:
+    def rpc(self, func: str, params: dict) -> SyncFilterRequestBuilder[Any]:
         """Perform a stored procedure call.
 
         Args:
@@ -94,6 +96,6 @@ class SyncPostgrestClient(BasePostgrestClient):
             filter on the RPC's resultset.
         """
         # the params here are params to be sent to the RPC and not the queryparams!
-        return SyncFilterRequestBuilder(
+        return SyncFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", "POST", Headers(), QueryParams(), json=params
         )

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -20,7 +20,7 @@ from ..base_request_builder import (
 )
 from ..exceptions import APIError, generate_default_error_message
 from ..types import ReturnMethod
-from ..utils import SyncClient
+from ..utils import SyncClient, get_origin_and_cast
 
 _ReturnT = TypeVar("_ReturnT")
 
@@ -154,13 +154,10 @@ class SyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], SyncQueryRequ
         params: QueryParams,
         json: dict,
     ) -> None:
-        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
-        # tries to call _GenericAlias.__init__ - which is the wrong method
-        # The __origin__ attribute of the _GenericAlias is the actual class
-        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseFilterRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        SyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(SyncQueryRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 
@@ -178,10 +175,10 @@ class SyncRPCFilterRequestBuilder(
         params: QueryParams,
         json: dict,
     ) -> None:
-        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseFilterRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        SyncSingleRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(SyncSingleRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 
@@ -197,13 +194,10 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], SyncQueryRequ
         params: QueryParams,
         json: dict,
     ) -> None:
-        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
-        # tries to call _GenericAlias.__init__ - which is the wrong method
-        # The __origin__ attribute of the _GenericAlias is the actual class
-        BaseSelectRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseSelectRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
-        SyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(SyncQueryRequestBuilder[_ReturnT]).__init__(
             self, session, path, http_method, headers, params, json
         )
 

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from json import JSONDecodeError
-from typing import Optional, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from httpx import Headers, QueryParams
 from pydantic import ValidationError
@@ -22,8 +22,10 @@ from ..exceptions import APIError, generate_default_error_message
 from ..types import ReturnMethod
 from ..utils import SyncClient
 
+_ReturnT = TypeVar("_ReturnT")
 
-class SyncQueryRequestBuilder:
+
+class SyncQueryRequestBuilder(Generic[_ReturnT]):
     def __init__(
         self,
         session: SyncClient,
@@ -40,7 +42,7 @@ class SyncQueryRequestBuilder:
         self.params = params
         self.json = json
 
-    def execute(self) -> APIResponse:
+    def execute(self) -> APIResponse[_ReturnT]:
         """Execute the query.
 
         .. tip::
@@ -63,7 +65,7 @@ class SyncQueryRequestBuilder:
             if (
                 200 <= r.status_code <= 299
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
-                return APIResponse.from_http_request_response(r)
+                return APIResponse[_ReturnT].from_http_request_response(r)
             else:
                 raise APIError(r.json())
         except ValidationError as e:
@@ -72,7 +74,7 @@ class SyncQueryRequestBuilder:
             raise APIError(generate_default_error_message(r))
 
 
-class SyncSingleRequestBuilder:
+class SyncSingleRequestBuilder(Generic[_ReturnT]):
     def __init__(
         self,
         session: SyncClient,
@@ -89,7 +91,7 @@ class SyncSingleRequestBuilder:
         self.params = params
         self.json = json
 
-    def execute(self) -> SingleAPIResponse:
+    def execute(self) -> SingleAPIResponse[_ReturnT]:
         """Execute the query.
 
         .. tip::
@@ -112,7 +114,7 @@ class SyncSingleRequestBuilder:
             if (
                 200 <= r.status_code <= 299
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
-                return SingleAPIResponse.from_http_request_response(r)
+                return SingleAPIResponse[_ReturnT].from_http_request_response(r)
             else:
                 raise APIError(r.json())
         except ValidationError as e:
@@ -121,11 +123,11 @@ class SyncSingleRequestBuilder:
             raise APIError(generate_default_error_message(r))
 
 
-class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder):
-    def execute(self) -> Optional[SingleAPIResponse]:
+class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder[_ReturnT]):
+    def execute(self) -> Optional[SingleAPIResponse[_ReturnT]]:
         r = None
         try:
-            r = super().execute()
+            r = SyncSingleRequestBuilder[_ReturnT].execute(self)
         except APIError as e:
             if e.details and "The result contains 0 rows" in e.details:
                 return None
@@ -142,7 +144,7 @@ class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder):
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class SyncFilterRequestBuilder(BaseFilterRequestBuilder, SyncQueryRequestBuilder):  # type: ignore
+class SyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]):  # type: ignore
     def __init__(
         self,
         session: SyncClient,
@@ -152,14 +154,19 @@ class SyncFilterRequestBuilder(BaseFilterRequestBuilder, SyncQueryRequestBuilder
         params: QueryParams,
         json: dict,
     ) -> None:
-        BaseFilterRequestBuilder.__init__(self, session, headers, params)
-        SyncQueryRequestBuilder.__init__(
+        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
+        # tries to call _GenericAlias.__init__ - which is the wrong method
+        # The __origin__ attribute of the _GenericAlias is the actual class
+        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, headers, params
+        )
+        SyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
             self, session, path, http_method, headers, params, json
         )
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder):  # type: ignore
+class SyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]):  # type: ignore
     def __init__(
         self,
         session: SyncClient,
@@ -169,19 +176,24 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder
         params: QueryParams,
         json: dict,
     ) -> None:
-        BaseSelectRequestBuilder.__init__(self, session, headers, params)
-        SyncQueryRequestBuilder.__init__(
+        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
+        # tries to call _GenericAlias.__init__ - which is the wrong method
+        # The __origin__ attribute of the _GenericAlias is the actual class
+        BaseSelectRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, headers, params
+        )
+        SyncQueryRequestBuilder[_ReturnT].__origin__.__init__(
             self, session, path, http_method, headers, params, json
         )
 
-    def single(self) -> SyncSingleRequestBuilder:
+    def single(self) -> SyncSingleRequestBuilder[_ReturnT]:
         """Specify that the query will only return a single row in response.
 
         .. caution::
             The API will raise an error if the query returned more than one row.
         """
         self.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return SyncSingleRequestBuilder(
+        return SyncSingleRequestBuilder[_ReturnT](
             headers=self.headers,
             http_method=self.http_method,
             json=self.json,
@@ -190,10 +202,10 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder
             session=self.session,  # type: ignore
         )
 
-    def maybe_single(self) -> SyncMaybeSingleRequestBuilder:
+    def maybe_single(self) -> SyncMaybeSingleRequestBuilder[_ReturnT]:
         """Retrieves at most one row from the result. Result must be at most one row (e.g. using `eq` on a UNIQUE column), otherwise this will result in an error."""
         self.headers["Accept"] = "application/vnd.pgrst.object+json"
-        return SyncMaybeSingleRequestBuilder(
+        return SyncMaybeSingleRequestBuilder[_ReturnT](
             headers=self.headers,
             http_method=self.http_method,
             json=self.json,
@@ -203,8 +215,8 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder
         )
 
     def text_search(
-        self, column: str, query: str, options: Dict[str, any] = {}
-    ) -> SyncFilterRequestBuilder:
+        self, column: str, query: str, options: dict[str, Any] = {}
+    ) -> SyncFilterRequestBuilder[_ReturnT]:
         type_ = options.get("type")
         type_part = ""
         if type_ == "plain":
@@ -216,7 +228,7 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder
         config_part = f"({options.get('config')})" if options.get("config") else ""
         self.params = self.params.add(column, f"{type_part}fts{config_part}.{query}")
 
-        return SyncQueryRequestBuilder(
+        return SyncQueryRequestBuilder[_ReturnT](
             headers=self.headers,
             http_method=self.http_method,
             json=self.json,
@@ -226,7 +238,7 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder, SyncQueryRequestBuilder
         )
 
 
-class SyncRequestBuilder:
+class SyncRequestBuilder(Generic[_ReturnT]):
     def __init__(self, session: SyncClient, path: str) -> None:
         self.session = session
         self.path = path
@@ -235,7 +247,7 @@ class SyncRequestBuilder:
         self,
         *columns: str,
         count: Optional[CountMethod] = None,
-    ) -> SyncSelectRequestBuilder:
+    ) -> SyncSelectRequestBuilder[_ReturnT]:
         """Run a SELECT query.
 
         Args:
@@ -245,7 +257,7 @@ class SyncRequestBuilder:
             :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_select(*columns, count=count)
-        return SyncSelectRequestBuilder(
+        return SyncSelectRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
         )
 
@@ -256,7 +268,7 @@ class SyncRequestBuilder:
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
         upsert: bool = False,
-    ) -> SyncQueryRequestBuilder:
+    ) -> SyncQueryRequestBuilder[_ReturnT]:
         """Run an INSERT query.
 
         Args:
@@ -273,7 +285,7 @@ class SyncRequestBuilder:
             returning=returning,
             upsert=upsert,
         )
-        return SyncQueryRequestBuilder(
+        return SyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
         )
 
@@ -285,7 +297,7 @@ class SyncRequestBuilder:
         returning: ReturnMethod = ReturnMethod.representation,
         ignore_duplicates: bool = False,
         on_conflict: str = "",
-    ) -> SyncQueryRequestBuilder:
+    ) -> SyncQueryRequestBuilder[_ReturnT]:
         """Run an upsert (INSERT ... ON CONFLICT DO UPDATE) query.
 
         Args:
@@ -304,7 +316,7 @@ class SyncRequestBuilder:
             ignore_duplicates=ignore_duplicates,
             on_conflict=on_conflict,
         )
-        return SyncQueryRequestBuilder(
+        return SyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
         )
 
@@ -314,7 +326,7 @@ class SyncRequestBuilder:
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> SyncFilterRequestBuilder:
+    ) -> SyncFilterRequestBuilder[_ReturnT]:
         """Run an UPDATE query.
 
         Args:
@@ -329,7 +341,7 @@ class SyncRequestBuilder:
             count=count,
             returning=returning,
         )
-        return SyncFilterRequestBuilder(
+        return SyncFilterRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
         )
 
@@ -338,7 +350,7 @@ class SyncRequestBuilder:
         *,
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
-    ) -> SyncFilterRequestBuilder:
+    ) -> SyncFilterRequestBuilder[_ReturnT]:
         """Run a DELETE query.
 
         Args:
@@ -351,7 +363,7 @@ class SyncRequestBuilder:
             count=count,
             returning=returning,
         )
-        return SyncFilterRequestBuilder(
+        return SyncFilterRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
         )
 

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -165,6 +165,27 @@ class SyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], SyncQueryRequ
         )
 
 
+# this exists for type-safety. see https://gist.github.com/anand2312/93d3abf401335fd3310d9e30112303bf
+class SyncRPCFilterRequestBuilder(
+    BaseFilterRequestBuilder[_ReturnT], SyncSingleRequestBuilder[_ReturnT]
+):
+    def __init__(
+        self,
+        session: SyncClient,
+        path: str,
+        http_method: str,
+        headers: Headers,
+        params: QueryParams,
+        json: dict,
+    ) -> None:
+        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, headers, params
+        )
+        SyncSingleRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, path, http_method, headers, params, json
+        )
+
+
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
 class SyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]):  # type: ignore
     def __init__(

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -127,7 +127,7 @@ _ReturnT = TypeVar("_ReturnT")
 # necessarily return lists.
 # https://github.com/supabase-community/postgrest-py/issues/200
 class APIResponse(BaseModel, Generic[_ReturnT]):
-    data: _ReturnT
+    data: list[_ReturnT]
     """The data returned by the query."""
     count: Optional[int] = None
     """The number of rows returned."""

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    List,
     NamedTuple,
     Optional,
     Tuple,
@@ -127,7 +128,7 @@ _ReturnT = TypeVar("_ReturnT")
 # necessarily return lists.
 # https://github.com/supabase-community/postgrest-py/issues/200
 class APIResponse(BaseModel, Generic[_ReturnT]):
-    data: list[_ReturnT]
+    data: List[_ReturnT]
     """The data returned by the query."""
     count: Optional[int] = None
     """The number of rows returned."""

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -6,8 +6,8 @@ from re import search
 from typing import (
     Any,
     Dict,
+    Generic,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Tuple,
@@ -19,6 +19,11 @@ from typing import (
 from httpx import Headers, QueryParams
 from httpx import Response as RequestResponse
 from pydantic import BaseModel
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 try:
     # >= 2.0.0
@@ -114,15 +119,22 @@ def pre_delete(
     return QueryArgs(RequestMethod.DELETE, QueryParams(), headers, {})
 
 
-class APIResponse(BaseModel):
-    data: List[Dict[str, Any]]
+_ReturnT = TypeVar("_ReturnT")
+
+
+# the APIResponse.data is marked as _ReturnT instead of list[_ReturnT]
+# as it is also returned in the case of rpc() calls; and rpc calls do not
+# necessarily return lists.
+# https://github.com/supabase-community/postgrest-py/issues/200
+class APIResponse(BaseModel, Generic[_ReturnT]):
+    data: _ReturnT
     """The data returned by the query."""
     count: Optional[int] = None
     """The number of rows returned."""
 
     @field_validator("data")
     @classmethod
-    def raise_when_api_error(cls: Type[APIResponse], value: Any) -> Any:
+    def raise_when_api_error(cls: Type[Self], value: Any) -> Any:
         if isinstance(value, dict) and value.get("message"):
             raise ValueError("You are passing an API error to the data field.")
         return value
@@ -141,7 +153,7 @@ class APIResponse(BaseModel):
 
     @classmethod
     def _get_count_from_http_request_response(
-        cls: Type[APIResponse],
+        cls: Type[Self],
         request_response: RequestResponse,
     ) -> Optional[int]:
         prefer_header: Optional[str] = request_response.request.headers.get("prefer")
@@ -159,51 +171,48 @@ class APIResponse(BaseModel):
 
     @classmethod
     def from_http_request_response(
-        cls: Type[APIResponse], request_response: RequestResponse
-    ) -> APIResponse:
+        cls: Type[Self], request_response: RequestResponse
+    ) -> Self:
         try:
             data = request_response.json()
         except JSONDecodeError as e:
             return cls(data=[], count=0)
         count = cls._get_count_from_http_request_response(request_response)
-        return cls(data=data, count=count)
+        # the type-ignore here is as pydantic needs us to pass the type parameter
+        # here explicitly, but pylance already knows that cls is correctly parametrized
+        return cls[_ReturnT](data=data, count=count)  # type: ignore
 
     @classmethod
-    def from_dict(cls: Type[APIResponse], dict: Dict[str, Any]) -> APIResponse:
+    def from_dict(cls: Type[Self], dict: Dict[str, Any]) -> Self:
         keys = dict.keys()
         assert len(keys) == 3 and "data" in keys and "count" in keys and "error" in keys
-        return cls(
+        return cls[_ReturnT](  # type: ignore
             data=dict.get("data"), count=dict.get("count"), error=dict.get("error")
         )
 
 
-class SingleAPIResponse(APIResponse):
-    data: Dict[str, Any]  # type: ignore
+class SingleAPIResponse(APIResponse[_ReturnT], Generic[_ReturnT]):
+    data: _ReturnT  # type: ignore
     """The data returned by the query."""
 
     @classmethod
     def from_http_request_response(
-        cls: Type[SingleAPIResponse], request_response: RequestResponse
-    ) -> SingleAPIResponse:
+        cls: Type[Self], request_response: RequestResponse
+    ) -> Self:
         data = request_response.json()
         count = cls._get_count_from_http_request_response(request_response)
-        return cls(data=data, count=count)
+        return cls[_ReturnT](data=data, count=count)  # type: ignore
 
     @classmethod
-    def from_dict(
-        cls: Type[SingleAPIResponse], dict: Dict[str, Any]
-    ) -> SingleAPIResponse:
+    def from_dict(cls: Type[Self], dict: Dict[str, Any]) -> Self:
         keys = dict.keys()
         assert len(keys) == 3 and "data" in keys and "count" in keys and "error" in keys
-        return cls(
+        return cls[_ReturnT](  # type: ignore
             data=dict.get("data"), count=dict.get("count"), error=dict.get("error")
         )
 
 
-_FilterT = TypeVar("_FilterT", bound="BaseFilterRequestBuilder")
-
-
-class BaseFilterRequestBuilder:
+class BaseFilterRequestBuilder(Generic[_ReturnT]):
     def __init__(
         self,
         session: Union[AsyncClient, SyncClient],
@@ -216,12 +225,12 @@ class BaseFilterRequestBuilder:
         self.negate_next = False
 
     @property
-    def not_(self: _FilterT) -> _FilterT:
+    def not_(self: Self) -> Self:
         """Whether the filter applied next should be negated."""
         self.negate_next = True
         return self
 
-    def filter(self: _FilterT, column: str, operator: str, criteria: str) -> _FilterT:
+    def filter(self: Self, column: str, operator: str, criteria: str) -> Self:
         """Apply filters on a query.
 
         Args:
@@ -236,7 +245,7 @@ class BaseFilterRequestBuilder:
         self.params = self.params.add(key, val)
         return self
 
-    def eq(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def eq(self: Self, column: str, value: Any) -> Self:
         """An 'equal to' filter.
 
         Args:
@@ -245,7 +254,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.EQ, value)
 
-    def neq(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def neq(self: Self, column: str, value: Any) -> Self:
         """A 'not equal to' filter
 
         Args:
@@ -254,7 +263,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.NEQ, value)
 
-    def gt(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def gt(self: Self, column: str, value: Any) -> Self:
         """A 'greater than' filter
 
         Args:
@@ -263,7 +272,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.GT, value)
 
-    def gte(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def gte(self: Self, column: str, value: Any) -> Self:
         """A 'greater than or equal to' filter
 
         Args:
@@ -272,7 +281,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.GTE, value)
 
-    def lt(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def lt(self: Self, column: str, value: Any) -> Self:
         """A 'less than' filter
 
         Args:
@@ -281,7 +290,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.LT, value)
 
-    def lte(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def lte(self: Self, column: str, value: Any) -> Self:
         """A 'less than or equal to' filter
 
         Args:
@@ -290,7 +299,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.LTE, value)
 
-    def is_(self: _FilterT, column: str, value: Any) -> _FilterT:
+    def is_(self: Self, column: str, value: Any) -> Self:
         """An 'is' filter
 
         Args:
@@ -299,7 +308,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.IS, value)
 
-    def like(self: _FilterT, column: str, pattern: str) -> _FilterT:
+    def like(self: Self, column: str, pattern: str) -> Self:
         """A 'LIKE' filter, to use for pattern matching.
 
         Args:
@@ -308,7 +317,7 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.LIKE, pattern)
 
-    def ilike(self: _FilterT, column: str, pattern: str) -> _FilterT:
+    def ilike(self: Self, column: str, pattern: str) -> Self:
         """An 'ILIKE' filter, to use for pattern matching (case insensitive).
 
         Args:
@@ -317,34 +326,34 @@ class BaseFilterRequestBuilder:
         """
         return self.filter(column, Filters.ILIKE, pattern)
 
-    def fts(self: _FilterT, column: str, query: Any) -> _FilterT:
+    def fts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.FTS, query)
 
-    def plfts(self: _FilterT, column: str, query: Any) -> _FilterT:
+    def plfts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.PLFTS, query)
 
-    def phfts(self: _FilterT, column: str, query: Any) -> _FilterT:
+    def phfts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.PHFTS, query)
 
-    def wfts(self: _FilterT, column: str, query: Any) -> _FilterT:
+    def wfts(self: Self, column: str, query: Any) -> Self:
         return self.filter(column, Filters.WFTS, query)
 
-    def in_(self: _FilterT, column: str, values: Iterable[Any]) -> _FilterT:
+    def in_(self: Self, column: str, values: Iterable[Any]) -> Self:
         values = map(sanitize_param, values)
         values = ",".join(values)
         return self.filter(column, Filters.IN, f"({values})")
 
-    def cs(self: _FilterT, column: str, values: Iterable[Any]) -> _FilterT:
+    def cs(self: Self, column: str, values: Iterable[Any]) -> Self:
         values = ",".join(values)
         return self.filter(column, Filters.CS, f"{{{values}}}")
 
-    def cd(self: _FilterT, column: str, values: Iterable[Any]) -> _FilterT:
+    def cd(self: Self, column: str, values: Iterable[Any]) -> Self:
         values = ",".join(values)
         return self.filter(column, Filters.CD, f"{{{values}}}")
 
     def contains(
-        self: _FilterT, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
-    ) -> _FilterT:
+        self: Self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
+    ) -> Self:
         if isinstance(value, str):
             # range types can be inclusive '[', ']' or exclusive '(', ')' so just
             # keep it simple and accept a string
@@ -357,8 +366,8 @@ class BaseFilterRequestBuilder:
         return self.filter(column, Filters.CS, json.dumps(value))
 
     def contained_by(
-        self: _FilterT, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
-    ) -> _FilterT:
+        self: Self, column: str, value: Union[Iterable[Any], str, Dict[Any, Any]]
+    ) -> Self:
         if isinstance(value, str):
             # range
             return self.filter(column, Filters.CD, value)
@@ -367,26 +376,26 @@ class BaseFilterRequestBuilder:
             return self.filter(column, Filters.CD, f"{{{stringified_values}}}")
         return self.filter(column, Filters.CD, json.dumps(value))
 
-    def ov(self: _FilterT, column: str, values: Iterable[Any]) -> _FilterT:
+    def ov(self: Self, column: str, values: Iterable[Any]) -> Self:
         values = ",".join(values)
         return self.filter(column, Filters.OV, f"{{{values}}}")
 
-    def sl(self: _FilterT, column: str, range: Tuple[int, int]) -> _FilterT:
+    def sl(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.SL, f"({range[0]},{range[1]})")
 
-    def sr(self: _FilterT, column: str, range: Tuple[int, int]) -> _FilterT:
+    def sr(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.SR, f"({range[0]},{range[1]})")
 
-    def nxl(self: _FilterT, column: str, range: Tuple[int, int]) -> _FilterT:
+    def nxl(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.NXL, f"({range[0]},{range[1]})")
 
-    def nxr(self: _FilterT, column: str, range: Tuple[int, int]) -> _FilterT:
+    def nxr(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.NXR, f"({range[0]},{range[1]})")
 
-    def adj(self: _FilterT, column: str, range: Tuple[int, int]) -> _FilterT:
+    def adj(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.ADJ, f"({range[0]},{range[1]})")
 
-    def match(self: _FilterT, query: Dict[str, Any]) -> _FilterT:
+    def match(self: Self, query: Dict[str, Any]) -> Self:
         updated_query = self
 
         if not query:
@@ -400,24 +409,29 @@ class BaseFilterRequestBuilder:
         return updated_query
 
 
-class BaseSelectRequestBuilder(BaseFilterRequestBuilder):
+class BaseSelectRequestBuilder(BaseFilterRequestBuilder[_ReturnT]):
     def __init__(
         self,
         session: Union[AsyncClient, SyncClient],
         headers: Headers,
         params: QueryParams,
     ) -> None:
-        BaseFilterRequestBuilder.__init__(self, session, headers, params)
+        # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
+        # tries to call _GenericAlias.__init__ - which is the wrong method
+        # The __origin__ attribute of the _GenericAlias is the actual class
+        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+            self, session, headers, params
+        )
 
     def explain(
-        self: _FilterT,
+        self: Self,
         analyze: bool = False,
         verbose: bool = False,
         settings: bool = False,
         buffers: bool = False,
         wal: bool = False,
         format: str = "",
-    ) -> _FilterT:
+    ) -> Self:
         options = [
             key
             for key, value in locals().items()
@@ -429,13 +443,13 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder):
         return self
 
     def order(
-        self: _FilterT,
+        self: Self,
         column: str,
         *,
         desc: bool = False,
         nullsfirst: bool = False,
         foreign_table: Optional[str] = None,
-    ) -> _FilterT:
+    ) -> Self:
         """Sort the returned rows in some specific order.
 
         Args:
@@ -452,9 +466,7 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder):
         )
         return self
 
-    def limit(
-        self: _FilterT, size: int, *, foreign_table: Optional[str] = None
-    ) -> _FilterT:
+    def limit(self: Self, size: int, *, foreign_table: Optional[str] = None) -> Self:
         """Limit the number of rows returned by a query.
 
         Args:
@@ -469,7 +481,7 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder):
         )
         return self
 
-    def range(self: _FilterT, start: int, end: int) -> _FilterT:
+    def range(self: Self, start: int, end: int) -> Self:
         self.headers["Range-Unit"] = "items"
         self.headers["Range"] = f"{start}-{end - 1}"
         return self

--- a/postgrest/utils.py
+++ b/postgrest/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar, cast, get_origin
 
 from httpx import AsyncClient  # noqa: F401
 from httpx import Client as BaseClient  # noqa: F401
@@ -21,3 +21,17 @@ def sanitize_param(param: Any) -> str:
 
 def sanitize_pattern_param(pattern: str) -> str:
     return sanitize_param(pattern.replace("%", "*"))
+
+
+_T = TypeVar("_T")
+
+
+def get_origin_and_cast(typ: type[type[_T]]) -> type[_T]:
+    # Base[T] is an instance of typing._GenericAlias, so doing Base[T].__init__
+    # tries to call _GenericAlias.__init__ - which is the wrong method
+    # get_origin(Base[T]) returns Base
+    # This function casts Base back to Base[T] to maintain type-safety
+    # while still allowing us to access the methods of `Base` at runtime
+    # See: definitions of request builders that use multiple-inheritance
+    # like AsyncFilterRequestBuilder
+    return cast(type[_T], get_origin(typ))

--- a/postgrest/utils.py
+++ b/postgrest/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar, cast, get_origin
+from typing import Any, Type, TypeVar, cast, get_origin
 
 from httpx import AsyncClient  # noqa: F401
 from httpx import Client as BaseClient  # noqa: F401
@@ -34,4 +34,4 @@ def get_origin_and_cast(typ: type[type[_T]]) -> type[_T]:
     # while still allowing us to access the methods of `Base` at runtime
     # See: definitions of request builders that use multiple-inheritance
     # like AsyncFilterRequestBuilder
-    return cast(type[_T], get_origin(typ))
+    return cast(Type[_T], get_origin(typ))


### PR DESCRIPTION
Fixes #200 
This PR makes all the request builders and the APIResponse classes generic;
- The type of the data to be returned by the query can now be passed down the builder chain and into the APIResponse class
- Pydantic then uses this type for any validation to be done
This fixes the issue by using `APIResponse[Any]` as the return type for rpc calls, while using `APIResponse[list[dict[str, Any]]` for other queries.
This also opens us up to (in the future) allowing users to pass in their own pydantic models to the query, so that the response is well-typed.

~~Marked as draft to write more tests~~