### PR TITLE
fix: pre-commit hook to stop checks on md files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          token: ${{ secrets.SILENTWORKS_PAT }}
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@v8.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '^.*\.(md|MD)$'
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ python-semantic-release = "^8.1.1"
 furo = "^2023.9.10"
 
 [tool.semantic_release]
-version_variable = "postgrest/__init__.py:__version__"
+version_variables = ["postgrest/__init__.py:__version__"]
 version_toml = ["pyproject.toml:tool.poetry.version"]
 major_on_zero = false
-commit_subject = "chore(release): bump version to v{version}"
+commit_message = "chore(release): bump version to v{version}"
 build_command = "curl -sSL https://install.python-poetry.org | python - && export PATH=\"/github/home/.local/bin:$PATH\" && poetry install && poetry build"
-upload_to_repository = true
+upload_to_vcs_release = true
 branch = "master"
 changelog_components = "semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix to stop the pre-commit hook from checking line ending on markdown files, using the correct token to publish a release and correct semantic releases variable names.

## What is the current behavior?



## What is the new behavior?



## Additional context

Add any other context or screenshots.
