### PR TITLE
feat: add csv() modifier

### DIFF
--- a/postgrest/__init__.py
+++ b/postgrest/__init__.py
@@ -10,6 +10,7 @@ from ._async.request_builder import (
     AsyncQueryRequestBuilder,
     AsyncRequestBuilder,
     AsyncSelectRequestBuilder,
+    AsyncSingleRequestBuilder,
 )
 from ._sync.client import SyncPostgrestClient
 from ._sync.request_builder import (
@@ -17,6 +18,7 @@ from ._sync.request_builder import (
     SyncQueryRequestBuilder,
     SyncRequestBuilder,
     SyncSelectRequestBuilder,
+    SyncSingleRequestBuilder,
 )
 from .base_request_builder import APIResponse
 from .constants import DEFAULT_POSTGREST_CLIENT_HEADERS

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -252,6 +252,18 @@ class AsyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], AsyncQueryRe
             session=self.session,  # type: ignore
         )
 
+    def csv(self) -> AsyncSingleRequestBuilder[str]:
+        """Specify that the query must retrieve data as a single CSV string."""
+        self.headers["Accept"] = "text/csv"
+        return AsyncSingleRequestBuilder[str](
+            session=self.session,  # type: ignore
+            path=self.path,
+            http_method=self.http_method,
+            headers=self.headers,
+            params=self.params,
+            json=self.json,
+        )
+
 
 class AsyncRequestBuilder(Generic[_ReturnT]):
     def __init__(self, session: AsyncClient, path: str) -> None:

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -252,6 +252,18 @@ class SyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], SyncQueryRequ
             session=self.session,  # type: ignore
         )
 
+    def csv(self) -> SyncSingleRequestBuilder[str]:
+        """Specify that the query must retrieve data as a single CSV string."""
+        self.headers["Accept"] = "text/csv"
+        return SyncSingleRequestBuilder[str](
+            session=self.session,  # type: ignore
+            path=self.path,
+            http_method=self.http_method,
+            headers=self.headers,
+            params=self.params,
+            json=self.json,
+        )
+
 
 class SyncRequestBuilder(Generic[_ReturnT]):
     def __init__(self, session: SyncClient, path: str) -> None:

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -204,10 +204,7 @@ class SingleAPIResponse(APIResponse[_ReturnT], Generic[_ReturnT]):
         try:
             data = request_response.json()
         except JSONDecodeError:
-            if len(request_response.text) > 0:
-                data = request_response.text
-            else:
-                data = []
+            data = request_response.text if len(request_response.text) > 0 else []
         return cls[_ReturnT](data=data, count=count)  # type: ignore
 
     @classmethod

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -200,8 +200,14 @@ class SingleAPIResponse(APIResponse[_ReturnT], Generic[_ReturnT]):
     def from_http_request_response(
         cls: Type[Self], request_response: RequestResponse
     ) -> Self:
-        data = request_response.json()
         count = cls._get_count_from_http_request_response(request_response)
+        try:
+            data = request_response.json()
+        except JSONDecodeError:
+            if len(request_response.text) > 0:
+                data = request_response.text
+            else:
+                data = []
         return cls[_ReturnT](data=data, count=count)  # type: ignore
 
     @classmethod

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -34,7 +34,7 @@ except ImportError:
     from pydantic import validator as field_validator
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
-from .utils import AsyncClient, SyncClient, sanitize_param
+from .utils import AsyncClient, SyncClient, get_origin_and_cast, sanitize_param
 
 
 class QueryArgs(NamedTuple):
@@ -420,7 +420,7 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[_ReturnT]):
         # Generic[T] is an instance of typing._GenericAlias, so doing Generic[T].__init__
         # tries to call _GenericAlias.__init__ - which is the wrong method
         # The __origin__ attribute of the _GenericAlias is the actual class
-        BaseFilterRequestBuilder[_ReturnT].__origin__.__init__(
+        get_origin_and_cast(BaseFilterRequestBuilder[_ReturnT]).__init__(
             self, session, headers, params
         )
 

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 import pytest
 from httpx import Request, Response
 
-from postgrest import SyncRequestBuilder
+from postgrest import SyncRequestBuilder, SyncSingleRequestBuilder
 from postgrest.base_request_builder import APIResponse, SingleAPIResponse
 from postgrest.types import CountMethod
 from postgrest.utils import SyncClient
@@ -35,6 +35,12 @@ class TestSelect:
         assert builder.headers["prefer"] == "count=exact"
         assert builder.http_method == "HEAD"
         assert builder.json == {}
+
+    def test_select_as_csv(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.select("*").csv()
+
+        assert builder.headers["Accept"] == "text/csv"
+        assert isinstance(builder, SyncSingleRequestBuilder)
 
 
 class TestInsert:
@@ -144,6 +150,11 @@ class TestExplain:
         assert 'options="analyze|verbose|buffers|wal;' in str(
             builder.headers.get("accept")
         )
+
+
+@pytest.fixture
+def csv_api_response() -> str:
+    return "id,name\n1,foo\n"
 
 
 @pytest.fixture
@@ -281,6 +292,15 @@ def request_response_with_single_data(
     )
 
 
+@pytest.fixture
+def request_response_with_csv_data(csv_api_response: str) -> Response:
+    return Response(
+        status_code=200,
+        text=csv_api_response,
+        request=Request(method="GET", url="http://example.com"),
+    )
+
+
 class TestApiResponse:
     def test_response_raises_when_api_error(
         self, api_response_with_error: Dict[str, Any]
@@ -374,3 +394,12 @@ class TestApiResponse:
         assert isinstance(result.data, dict)
         assert result.data == single_api_response
         assert result.count == 2
+
+    def test_single_with_csv_data(
+        self, request_response_with_csv_data: Response, csv_api_response: str
+    ):
+        result = SingleAPIResponse.from_http_request_response(
+            request_response_with_csv_data
+        )
+        assert isinstance(result.data, str)
+        assert result.data == csv_api_response


### PR DESCRIPTION
Notes:
- Adding a .csv() to the chain will eventually return a  `SingleAPIResposne[str]`, whose `data` field will be the data returned as a CSV string.
- Calling csv() has a similar effect as calling single() - it has to be the last call in the chain (only .execute() can follow it)