### PR TITLE
chore: add python 3.12 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Clone Repository


### PR DESCRIPTION
CPython 3.12 was [released](https://www.python.org/downloads/release/python-3120/) yesterday - let's add that to our testing matrix.