### PR TITLE
fix: make rpc function sync

### DIFF
--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -78,7 +78,7 @@ class AsyncPostgrestClient(BasePostgrestClient):
         """Alias to :meth:`from_`."""
         return self.from_(table)
 
-    async def rpc(self, func: str, params: dict) -> AsyncRPCFilterRequestBuilder[Any]:
+    def rpc(self, func: str, params: dict) -> AsyncRPCFilterRequestBuilder[Any]:
         """Perform a stored procedure call.
 
         Args:


### PR DESCRIPTION
## What kind of change does this PR introduce?
Makes the `.rpc` function synchronous

## What is the current behavior?
As `.rpc` was async but it only returned a FilterBuilder, the examples shown in docs would fail saying
```
    response = await client.rpc(...).execute()
AttributeError: 'coroutine' object has no attribute 'execute'
sys:1: RuntimeWarning: coroutine 'AsyncPostgrestClient.rpc' was never awaited
``` 
This meant that you'd need to double await, like
```py
response = await (await client.rpc(...)).execute()
```
## Additional context
[Discord help thread](https://discord.com/channels/839993398554656828/1162309992523763783)
