### PR TITLE
fix: add missing exports

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -481,20 +481,20 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.40"
+version = "3.1.41"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.40-py3-none-any.whl", hash = "sha256:cf14627d5a8049ffbf49915732e5eddbe8134c3bdb9d476e6182b676fc573f8a"},
-    {file = "GitPython-3.1.40.tar.gz", hash = "sha256:22b126e9ffb671fdd0c129796343a02bf67bf2994b35449ffc9321aa755e18a4"},
+    {file = "GitPython-3.1.41-py3-none-any.whl", hash = "sha256:c36b6634d069b3f719610175020a9aed919421c87552185b085e04fbbdb10b7c"},
+    {file = "GitPython-3.1.41.tar.gz", hash = "sha256:ed66e624884f76df22c8e16066d567aaa5a37d5b5fa19db2c6df6f7156db9048"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-sugar"]
+test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "sumtypes"]
 
 [[package]]
 name = "h11"
@@ -652,13 +652,13 @@ colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]

--- a/postgrest/__init__.py
+++ b/postgrest/__init__.py
@@ -7,16 +7,20 @@ from httpx import Timeout
 from ._async.client import AsyncPostgrestClient
 from ._async.request_builder import (
     AsyncFilterRequestBuilder,
+    AsyncMaybeSingleRequestBuilder,
     AsyncQueryRequestBuilder,
     AsyncRequestBuilder,
+    AsyncRPCFilterRequestBuilder,
     AsyncSelectRequestBuilder,
     AsyncSingleRequestBuilder,
 )
 from ._sync.client import SyncPostgrestClient
 from ._sync.request_builder import (
     SyncFilterRequestBuilder,
+    SyncMaybeSingleRequestBuilder,
     SyncQueryRequestBuilder,
     SyncRequestBuilder,
+    SyncRPCFilterRequestBuilder,
     SyncSelectRequestBuilder,
     SyncSingleRequestBuilder,
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Exporting `AsyncRPCFilterRequestBuilder`, `AsyncMaybeSingleRequestBuilder`, `RPCFilterRequestBuilder` and `MaybeSingleRequestBuilder` from the package main namespace

## What is the current behavior?

The package wasn't exporting the `AsyncRPCFilterRequestBuilder`, `AsyncMaybeSingleRequestBuilder`, `RPCFilterRequestBuilder` and `MaybeSingleRequestBuilder` from its main namespace

## What is the new behavior?

The package now exports the `AsyncRPCFilterRequestBuilder`, `AsyncMaybeSingleRequestBuilder`, `RPCFilterRequestBuilder` and `MaybeSingleRequestBuilder` from its main namespace

## Additional context

Add any other context or screenshots.
