### PR TITLE
update range to use query parameters instead of headers

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -565,7 +565,14 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[_ReturnT]):
         )
         return self
 
-    def range(self: Self, start: int, end: int) -> Self:
-        self.headers["Range-Unit"] = "items"
-        self.headers["Range"] = f"{start}-{end - 1}"
+    def range(
+        self: Self, start: int, end: int, foreign_table: Optional[str] = None
+    ) -> Self:
+        self.params = self.params.add(
+            f"{foreign_table}.offset" if foreign_table else "offset", start
+        )
+        self.params = self.params.add(
+            f"{foreign_table}.limit" if foreign_table else "limit",
+            end - start + 1,
+        )
         return self

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -152,6 +152,21 @@ class TestExplain:
         )
 
 
+class TestRange:
+    def test_range_on_own_table(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.select("*").range(0, 1)
+        assert builder.params["select"] == "*"
+        assert builder.params["limit"] == "2"
+        assert builder.params["offset"] == "0"
+
+    def test_range_on_foreign_table(self, request_builder: AsyncRequestBuilder):
+        foreign_table = "cities"
+        builder = request_builder.select("*").range(1, 2, foreign_table)
+        assert builder.params["select"] == "*"
+        assert builder.params[f"{foreign_table}.limit"] == "2"
+        assert builder.params[f"{foreign_table}.offset"] == "1"
+
+
 @pytest.fixture
 def csv_api_response() -> str:
     return "id,name\n1,foo\n"

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -152,6 +152,21 @@ class TestExplain:
         )
 
 
+class TestRange:
+    def test_range_on_own_table(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.select("*").range(0, 1)
+        assert builder.params["select"] == "*"
+        assert builder.params["limit"] == "2"
+        assert builder.params["offset"] == "0"
+
+    def test_range_on_foreign_table(self, request_builder: SyncRequestBuilder):
+        foreign_table = "cities"
+        builder = request_builder.select("*").range(1, 2, foreign_table)
+        assert builder.params["select"] == "*"
+        assert builder.params[f"{foreign_table}.limit"] == "2"
+        assert builder.params[f"{foreign_table}.offset"] == "1"
+
+
 @pytest.fixture
 def csv_api_response() -> str:
     return "id,name\n1,foo\n"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`.range` doesn't work with `.rpc` calls as these are POST requests and range only works with GET requests

## What is the new behavior?

`.range` now works with `.rpc` calls

## Additional context

Add any other context or screenshots.
