### PR TITLE
Upsert / Insert with default_to_null boolean argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run Tests
       run: make run_tests
     - name: Upload Coverage
-      uses: codecov/codecov-action@v4.1.1
+      uses: codecov/codecov-action@v4.1.0
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run Tests
       run: make run_tests
     - name: Upload Coverage
-      uses: codecov/codecov-action@v4.1.0
+      uses: codecov/codecov-action@4.1.1
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run Tests
       run: make run_tests
     - name: Upload Coverage
-      uses: codecov/codecov-action@4.1.1
+      uses: codecov/codecov-action@4.1.0
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run Tests
       run: make run_tests
     - name: Upload Coverage
-      uses: codecov/codecov-action@4.1.0
+      uses: codecov/codecov-action@v4.1.1
 
   publish:
     needs: test

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -312,8 +312,8 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
             upsert: Whether the query should be an upsert.
-            default_to_null: Make missing fields default to `null`. 
-                Otherwise, use the default value for the column. 
+            default_to_null: Make missing fields default to `null`.
+                Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
             :class:`AsyncQueryRequestBuilder`
@@ -347,9 +347,9 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             returning: Either 'minimal' or 'representation'
             ignore_duplicates: Whether duplicate rows should be ignored.
             on_conflict: Specified columns to be made to work with UNIQUE constraint.
-            default_to_null: Make missing fields default to `null`. Otherwise, use the 
-                default value for the column. This only applies when inserting new rows, 
-                not when merging with existing rows under `ignoreDuplicates: false`. 
+            default_to_null: Make missing fields default to `null`. Otherwise, use the
+                default value for the column. This only applies when inserting new rows,
+                not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
             :class:`AsyncQueryRequestBuilder`

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -303,6 +303,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
         upsert: bool = False,
+        default_to_null: bool = True,
     ) -> AsyncQueryRequestBuilder[_ReturnT]:
         """Run an INSERT query.
 
@@ -311,6 +312,9 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
             upsert: Whether the query should be an upsert.
+            default_to_null: Make missing fields default to `null`. 
+                Otherwise, use the default value for the column. 
+                Only applies for bulk inserts.
         Returns:
             :class:`AsyncQueryRequestBuilder`
         """
@@ -319,6 +323,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             count=count,
             returning=returning,
             upsert=upsert,
+            default_to_null=default_to_null,
         )
         return AsyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
@@ -332,6 +337,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
         returning: ReturnMethod = ReturnMethod.representation,
         ignore_duplicates: bool = False,
         on_conflict: str = "",
+        default_to_null: bool = True,
     ) -> AsyncQueryRequestBuilder[_ReturnT]:
         """Run an upsert (INSERT ... ON CONFLICT DO UPDATE) query.
 
@@ -341,6 +347,10 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             returning: Either 'minimal' or 'representation'
             ignore_duplicates: Whether duplicate rows should be ignored.
             on_conflict: Specified columns to be made to work with UNIQUE constraint.
+            default_to_null: Make missing fields default to `null`. Otherwise, use the 
+                default value for the column. This only applies when inserting new rows, 
+                not when merging with existing rows under `ignoreDuplicates: false`. 
+                This also only applies when doing bulk upserts.
         Returns:
             :class:`AsyncQueryRequestBuilder`
         """
@@ -350,6 +360,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
             returning=returning,
             ignore_duplicates=ignore_duplicates,
             on_conflict=on_conflict,
+            default_to_null=default_to_null,
         )
         return AsyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from json import JSONDecodeError
-from typing import Any, Generic, Optional, TypeVar, Union, List, Dict
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from httpx import Headers, QueryParams
 from pydantic import ValidationError
@@ -312,8 +312,8 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
             upsert: Whether the query should be an upsert.
-            default_to_null: Make missing fields default to `null`. 
-                Otherwise, use the default value for the column. 
+            default_to_null: Make missing fields default to `null`.
+                Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
             :class:`SyncQueryRequestBuilder`
@@ -347,9 +347,9 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             returning: Either 'minimal' or 'representation'
             ignore_duplicates: Whether duplicate rows should be ignored.
             on_conflict: Specified columns to be made to work with UNIQUE constraint.
-            default_to_null: Make missing fields default to `null`. Otherwise, use the 
-                default value for the column. This only applies when inserting new rows, 
-                not when merging with existing rows under `ignoreDuplicates: false`. 
+            default_to_null: Make missing fields default to `null`. Otherwise, use the
+                default value for the column. This only applies when inserting new rows,
+                not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
             :class:`SyncQueryRequestBuilder`

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -289,7 +289,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             *columns: The names of the columns to fetch.
             count: The method to use to get the count of rows returned.
         Returns:
-            :class:`AsyncSelectRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_select(*columns, count=count)
         return SyncSelectRequestBuilder[_ReturnT](
@@ -380,7 +380,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`SyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_update(
             json,
@@ -403,7 +403,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`SyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_delete(
             count=count,

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from json import JSONDecodeError
-from typing import Any, Generic, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, TypeVar, Union, List, Dict
 
 from httpx import Headers, QueryParams
 from pydantic import ValidationError
@@ -34,7 +34,7 @@ class SyncQueryRequestBuilder(Generic[_ReturnT]):
         http_method: str,
         headers: Headers,
         params: QueryParams,
-        json: dict,
+        json: Union[dict, list],
     ) -> None:
         self.session = session
         self.path = path
@@ -303,6 +303,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
         count: Optional[CountMethod] = None,
         returning: ReturnMethod = ReturnMethod.representation,
         upsert: bool = False,
+        default_to_null: bool = True,
     ) -> SyncQueryRequestBuilder[_ReturnT]:
         """Run an INSERT query.
 
@@ -311,14 +312,18 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
             upsert: Whether the query should be an upsert.
+            default_to_null: Make missing fields default to `null`. 
+                Otherwise, use the default value for the column. 
+                Only applies for bulk inserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`SyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_insert(
             json,
             count=count,
             returning=returning,
             upsert=upsert,
+            default_to_null=default_to_null,
         )
         return SyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json
@@ -332,6 +337,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
         returning: ReturnMethod = ReturnMethod.representation,
         ignore_duplicates: bool = False,
         on_conflict: str = "",
+        default_to_null: bool = True,
     ) -> SyncQueryRequestBuilder[_ReturnT]:
         """Run an upsert (INSERT ... ON CONFLICT DO UPDATE) query.
 
@@ -341,8 +347,12 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             returning: Either 'minimal' or 'representation'
             ignore_duplicates: Whether duplicate rows should be ignored.
             on_conflict: Specified columns to be made to work with UNIQUE constraint.
+            default_to_null: Make missing fields default to `null`. Otherwise, use the 
+                default value for the column. This only applies when inserting new rows, 
+                not when merging with existing rows under `ignoreDuplicates: false`. 
+                This also only applies when doing bulk upserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`SyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_upsert(
             json,
@@ -350,6 +360,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             returning=returning,
             ignore_duplicates=ignore_duplicates,
             on_conflict=on_conflict,
+            default_to_null=default_to_null,
         )
         return SyncQueryRequestBuilder[_ReturnT](
             self.session, self.path, method, headers, params, json

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -45,6 +45,7 @@ class QueryArgs(NamedTuple):
     headers: Headers
     json: Dict[Any, Any]
 
+
 def _unique_columns(json: List[Dict]):
     unique_keys = {key for row in json for key in row.keys()}
     columns = ",".join([f'"{k}"' for k in unique_keys])

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -73,7 +73,7 @@ class TestInsert:
     
     def test_upsert_with_default_single(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.upsert(
-            {"key1": "val1"}
+            [{"key1": "val1"}]
         , default_to_null=False)
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
@@ -81,8 +81,8 @@ class TestInsert:
             "missing=default",
         ]
         assert builder.http_method == "POST"
-        assert builder.json == {"key1": "val1"}, {"key3": "val3"}
-        assert builder.params.get("columns") is None
+        assert builder.json == [{"key1": "val1"}]
+        assert builder.params.get("columns") == '"key1"'
     
     def test_bulk_insert_using_default(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.insert([

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -70,6 +70,18 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
+    
+    def test_bullk_insert_using_default(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.insert([
+            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
+        ], default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
+        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
 
     def test_upsert(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.upsert({"key1": "val1"})
@@ -80,6 +92,19 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
+
+    def test_bulk_upsert_with_default(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.upsert([
+            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
+        ], default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "resolution=merge-duplicates",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
+        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
 
 
 class TestUpdate:

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -71,7 +71,7 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
     
-    def test_bullk_insert_using_default(self, request_builder: AsyncRequestBuilder):
+    def test_bulk_insert_using_default(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.insert([
             {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
         ], default_to_null=False)

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -71,6 +71,19 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
     
+    def test_upsert_with_default_single(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.upsert(
+            {"key1": "val1"}
+        , default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "resolution=merge-duplicates",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == {"key1": "val1"}, {"key3": "val3"}
+        assert builder.params.get("columns") is None
+    
     def test_bulk_insert_using_default(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.insert([
             {"key1": "val1", "key2": "val2"}, {"key3": "val3"}

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -70,11 +70,9 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
-    
+
     def test_upsert_with_default_single(self, request_builder: AsyncRequestBuilder):
-        builder = request_builder.upsert(
-            [{"key1": "val1"}]
-        , default_to_null=False)
+        builder = request_builder.upsert([{"key1": "val1"}], default_to_null=False)
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "resolution=merge-duplicates",
@@ -83,18 +81,20 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1"}]
         assert builder.params.get("columns") == '"key1"'
-    
+
     def test_bulk_insert_using_default(self, request_builder: AsyncRequestBuilder):
-        builder = request_builder.insert([
-            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
-        ], default_to_null=False)
+        builder = request_builder.insert(
+            [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
+        )
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "missing=default",
         ]
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
-        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
+        assert set(builder.params["columns"].split(",")) == set(
+            '"key1","key2","key3"'.split(",")
+        )
 
     def test_upsert(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.upsert({"key1": "val1"})
@@ -107,9 +107,9 @@ class TestInsert:
         assert builder.json == {"key1": "val1"}
 
     def test_bulk_upsert_with_default(self, request_builder: AsyncRequestBuilder):
-        builder = request_builder.upsert([
-            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
-        ], default_to_null=False)
+        builder = request_builder.upsert(
+            [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
+        )
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "resolution=merge-duplicates",
@@ -117,7 +117,9 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
-        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
+        assert set(builder.params["columns"].split(",")) == set(
+            '"key1","key2","key3"'.split(",")
+        )
 
 
 class TestUpdate:

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -93,6 +93,19 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
         
+    def test_upsert_with_default_single(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.upsert(
+            {"key1": "val1"}
+        , default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "resolution=merge-duplicates",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == {"key1": "val1"}, {"key3": "val3"}
+        assert builder.params.get("columns") is None
+        
     def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert([
             {"key1": "val1", "key2": "val2"}, {"key3": "val3"}

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -95,7 +95,7 @@ class TestInsert:
         
     def test_upsert_with_default_single(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert(
-            {"key1": "val1"}
+            [{"key1": "val1"}]
         , default_to_null=False)
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
@@ -103,8 +103,8 @@ class TestInsert:
             "missing=default",
         ]
         assert builder.http_method == "POST"
-        assert builder.json == {"key1": "val1"}, {"key3": "val3"}
-        assert builder.params.get("columns") is None
+        assert builder.json == [{"key1": "val1"}]
+        assert builder.params.get("columns") == '"key1"'
         
     def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert([

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -71,7 +71,7 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
         
-    def test_bullk_insert_using_default(self, request_builder: SyncRequestBuilder):
+    def test_bulk_insert_using_default(self, request_builder: SyncRequestBuilder):
         builder = request_builder.insert([
             {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
         ], default_to_null=False)

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -70,19 +70,21 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
-        
+
     def test_bulk_insert_using_default(self, request_builder: SyncRequestBuilder):
-        builder = request_builder.insert([
-            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
-        ], default_to_null=False)
+        builder = request_builder.insert(
+            [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
+        )
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "missing=default",
         ]
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
-        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
-        
+        assert set(builder.params["columns"].split(",")) == set(
+            '"key1","key2","key3"'.split(",")
+        )
+
     def test_upsert(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert({"key1": "val1"})
 
@@ -92,11 +94,9 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
-        
+
     def test_upsert_with_default_single(self, request_builder: SyncRequestBuilder):
-        builder = request_builder.upsert(
-            [{"key1": "val1"}]
-        , default_to_null=False)
+        builder = request_builder.upsert([{"key1": "val1"}], default_to_null=False)
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "resolution=merge-duplicates",
@@ -105,11 +105,11 @@ class TestInsert:
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1"}]
         assert builder.params.get("columns") == '"key1"'
-        
+
     def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
-        builder = request_builder.upsert([
-            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
-        ], default_to_null=False)
+        builder = request_builder.upsert(
+            [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}], default_to_null=False
+        )
         assert builder.headers.get_list("prefer", True) == [
             "return=representation",
             "resolution=merge-duplicates",
@@ -117,7 +117,9 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
-        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
+        assert set(builder.params["columns"].split(",")) == set(
+            '"key1","key2","key3"'.split(",")
+        )
 
 
 class TestUpdate:

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -70,7 +70,19 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
-
+        
+    def test_bullk_insert_using_default(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.insert([
+            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
+        ], default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
+        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
+        
     def test_upsert(self, request_builder: SyncRequestBuilder):
         builder = request_builder.upsert({"key1": "val1"})
 
@@ -80,6 +92,19 @@ class TestInsert:
         ]
         assert builder.http_method == "POST"
         assert builder.json == {"key1": "val1"}
+        
+    def test_bulk_upsert_with_default(self, request_builder: SyncRequestBuilder):
+        builder = request_builder.upsert([
+            {"key1": "val1", "key2": "val2"}, {"key3": "val3"}
+        ], default_to_null=False)
+        assert builder.headers.get_list("prefer", True) == [
+            "return=representation",
+            "resolution=merge-duplicates",
+            "missing=default",
+        ]
+        assert builder.http_method == "POST"
+        assert builder.json == [{"key1": "val1", "key2": "val2"}, {"key3": "val3"}]
+        assert set(builder.params["columns"].split(",")) == set('"key1","key2","key3"'.split(","))
 
 
 class TestUpdate:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / Bug Fix: adding the `default_to_null` parameter for `upsert` and `insert` methods as presented in both JavaScript and Dart/Flutter version of the client.

## What is the current behavior?

When doing bulk insert/upsert of rows into the Postgresql table, the missing fields are default to Nulls instead of using the default value of the column. The parameter `default_to_null` allows the user to use default values from the column definition, instead of using Nulls. But this parameter is currently not exposed in the Python client, though they are available in both JavaScript and Dart/Flutter clients.

## What is the new behavior?

When `default_to_null = True` (default value), the current behavior withholds, where missing fields from the json payload will be inserted using Null. 

When setting `default_to_null = False` AND user is performing bulk insert / upsert (i.e. json payload is a list of dictionary), the rows will be inserted with default values from the table/column definitions, rather than using Nulls.

This is done by setting two things in the PostgREST call:

* Adding `columns="column1","column2"` in the query parameter of the POST call
* Adding `Prefer: missing=default` in the header of the POST call.

The documentation from both Dart/Flutter and Javascript has indicated that setting `default_to_null = False` only applies to bulk insertion/upsersion: https://supabase.com/docs/reference/javascript/insert. Therefore, to update a single record, the user can wrap the json/dict as a list, i.e. `[insert_dict]`.


* Linked issue: https://github.com/supabase-community/postgrest-py/issues/370
* Compare similar PR in Dart/Flutter client: https://github.com/supabase/supabase-flutter/pull/550/files
* Compare similar PR in JavaScript client: https://github.com/supabase/postgrest-js/pull/417/files
