### PR TITLE
fix: update overlaps to work with timestamp range

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -451,9 +451,16 @@ class BaseFilterRequestBuilder(Generic[_ReturnT]):
             return self.filter(column, Filters.CD, f"{{{stringified_values}}}")
         return self.filter(column, Filters.CD, json.dumps(value))
 
-    def ov(self: Self, column: str, values: Iterable[Any]) -> Self:
-        values = ",".join(values)
-        return self.filter(column, Filters.OV, f"{{{values}}}")
+    def ov(self: Self, column: str, value: Iterable[Any]) -> Self:
+        if isinstance(value, str):
+            # range types can be inclusive '[', ']' or exclusive '(', ')' so just
+            # keep it simple and accept a string
+            return self.filter(column, Filters.OV, value)
+        if not isinstance(value, dict) and isinstance(value, Iterable):
+            # Expected to be some type of iterable
+            stringified_values = ",".join(value)
+            return self.filter(column, Filters.OV, f"{{{stringified_values}}}")
+        return self.filter(column, Filters.OV, json.dumps(value))
 
     def sl(self: Self, column: str, range: Tuple[int, int]) -> Self:
         return self.filter(column, Filters.SL, f"({range[0]},{range[1]})")

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -178,6 +178,15 @@ def test_overlaps(filter_request_builder):
     assert str(builder.params) == "x=ov.%7Bis%3Aclosed%2Cseverity%3Ahigh%7D"
 
 
+def test_overlaps_with_timestamp_range(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", "[2000-01-01 12:45, 2000-01-01 13:15)")
+
+    # {a,["b",%20"c"]}
+    assert (
+        str(builder.params) == "x=ov.%5B2000-01-01%2012%3A45%2C%202000-01-01%2013%3A15%29"
+    )
+
+
 def test_like(filter_request_builder):
     builder = filter_request_builder.like("x", "%a%")
 

--- a/tests/_async/test_filter_request_builder_integration.py
+++ b/tests/_async/test_filter_request_builder_integration.py
@@ -200,6 +200,20 @@ async def test_overlaps():
     ]
 
 
+async def test_overlaps_with_timestamp_range():
+    res = (
+        await rest_client()
+        .from_("reservations")
+        .select("room_name")
+        .overlaps("during", "[2000-01-01 12:45, 2000-01-01 13:15)")
+        .execute()
+    )
+
+    assert res.data == [
+        {"room_name": "Emerald"},
+    ]
+
+
 async def test_like():
     res = (
         await rest_client()

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -178,6 +178,15 @@ def test_overlaps(filter_request_builder):
     assert str(builder.params) == "x=ov.%7Bis%3Aclosed%2Cseverity%3Ahigh%7D"
 
 
+def test_overlaps_with_timestamp_range(filter_request_builder):
+    builder = filter_request_builder.overlaps("x", "[2000-01-01 12:45, 2000-01-01 13:15)")
+
+    # {a,["b",%20"c"]}
+    assert (
+        str(builder.params) == "x=ov.%5B2000-01-01%2012%3A45%2C%202000-01-01%2013%3A15%29"
+    )
+
+
 def test_like(filter_request_builder):
     builder = filter_request_builder.like("x", "%a%")
 

--- a/tests/_sync/test_filter_request_builder_integration.py
+++ b/tests/_sync/test_filter_request_builder_integration.py
@@ -193,6 +193,20 @@ def test_overlaps():
     ]
 
 
+def test_overlaps_with_timestamp_range():
+    res = (
+        rest_client()
+        .from_("reservations")
+        .select("room_name")
+        .overlaps("during", "[2000-01-01 12:45, 2000-01-01 13:15)")
+        .execute()
+    )
+
+    assert res.data == [
+        {"room_name": "Emerald"},
+    ]
+
+
 def test_like():
     res = (
         rest_client()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the overlaps feature

## What is the current behavior?

`overlaps` currently doesn't cater for timestamp range

## What is the new behavior?

`overlaps` now caters for timestamp range

## Additional context

Add any other context or screenshots.
