### PR TITLE
fix: convert None to a string null for the is method

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -330,6 +330,8 @@ class BaseFilterRequestBuilder(Generic[_ReturnT]):
             column: The name of the column to apply a filter on
             value: The value to filter by
         """
+        if value is None:
+            value = "null"
         return self.filter(column, Filters.IS, value)
 
     def like(self: Self, column: str, pattern: str) -> Self:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adding support for Python None type

## What is the current behavior?

You cannot use `None` type with the `is_` method.

## What is the new behavior?

You can use the `None` type with the `is_` method.

## Additional context

Add any other context or screenshots.
