### PR TITLE
fix(pydantic): model_validate_json causing code break with pydantic v1

### DIFF
--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -20,7 +20,7 @@ from ..base_request_builder import (
 )
 from ..exceptions import APIError, APIErrorFromJSON, generate_default_error_message
 from ..types import ReturnMethod
-from ..utils import get_origin_and_cast
+from ..utils import get_origin_and_cast, model_validate_json
 
 _ReturnT = TypeVar("_ReturnT")
 
@@ -74,7 +74,7 @@ class AsyncQueryRequestBuilder(Generic[_ReturnT]):
                             return body
                 return APIResponse[_ReturnT].from_http_request_response(r)
             else:
-                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
@@ -122,7 +122,7 @@ class AsyncSingleRequestBuilder(Generic[_ReturnT]):
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return SingleAPIResponse[_ReturnT].from_http_request_response(r)
             else:
-                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -20,7 +20,7 @@ from ..base_request_builder import (
 )
 from ..exceptions import APIError, APIErrorFromJSON, generate_default_error_message
 from ..types import ReturnMethod
-from ..utils import get_origin_and_cast
+from ..utils import get_origin_and_cast, model_validate_json
 
 _ReturnT = TypeVar("_ReturnT")
 
@@ -74,7 +74,7 @@ class SyncQueryRequestBuilder(Generic[_ReturnT]):
                             return body
                 return APIResponse[_ReturnT].from_http_request_response(r)
             else:
-                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))
@@ -122,7 +122,7 @@ class SyncSingleRequestBuilder(Generic[_ReturnT]):
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return SingleAPIResponse[_ReturnT].from_http_request_response(r)
             else:
-                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                json_obj = model_validate_json(APIErrorFromJSON, r.content)
                 raise APIError(dict(json_obj))
         except ValidationError as e:
             raise APIError(generate_default_error_message(r))

--- a/postgrest/utils.py
+++ b/postgrest/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from deprecation import deprecated
 from httpx import AsyncClient  # noqa: F401
 from httpx import Client as BaseClient  # noqa: F401
+from pydantic import BaseModel
 
 from .version import __version__
 
@@ -81,3 +82,17 @@ def is_valid_jwt(value: str) -> bool:
             return False
 
     return True
+
+
+TBaseModel = TypeVar("TBaseModel", bound=BaseModel)
+
+
+def model_validate_json(model: Type[TBaseModel], contents) -> TBaseModel:
+    """Compatibility layer between pydantic 1 and 2 for parsing an instance
+    of a BaseModel from varied"""
+    try:
+        # pydantic > 2
+        return model.model_validate_json(contents)
+    except AttributeError:
+        # pydantic < 2
+        return model.parse_raw(contents)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Add model_validate_json methods which works with both pydantic v1 and v2

## What is the current behavior?

An error is thrown if you use pydantic v1 with this library

## What is the new behavior?

The library is now compatible with both pydantic v1 and v2

## Additional context

Fixes #608 